### PR TITLE
v6.8.9: auto-cleanup staging dirs for failed/terminal jobs

### DIFF
--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -6,23 +6,21 @@ Versão: 6.8.8
 Data: 08/06/2026
 --------------------------------------------------------------------------------
 
-Fix: dispatcher despachava RETRY_WAIT sem esperar backoff — resume não funcionava
+Dispatcher backoff fix + h264 deletion delay padrão 5 min
 
-  [BUG] O dispatcher incluía RETRY_WAIT nos estados de download, despachando
-        jobs falhados imediatamente (~2s) em vez de respeitar o backoff
-        exponencial (10s→20s→40s→...). Isso fazia o resume nunca funcionar:
-        o job era re-despachado tão rápido que o .partial não era encontrado
-        pelo próximo worker.
+  [FIX] dispatcher re-despachava jobs em RETRY_WAIT direto pro download,
+        ignorando o backoff exponencial do watchdog. Jobs falhados voltavam
+        em ~2s ao invés de esperar min(300, 5×2^retry). Corrigido removendo
+        RETRY_WAIT do DOWNLOAD_STATES — agora só o watchdog promove
+        RETRY_WAIT → NEW após o delay correto.
 
-  [FIX] Removido RETRY_WAIT de DOWNLOAD_STATES no dispatcher. Agora apenas
-        o watchdog transiciona RETRY_WAIT → NEW após o delay correto.
-        O download resume agora funciona como projetado: o .partial é
-        preservado, o backoff é respeitado, e o próximo worker encontra
-        o arquivo parcial e continua de onde parou.
+  [CHANGE] default de legacy_reorganize_delete_h264_after_seconds mudou
+           de 0 (manter para sempre) para 300 (5 minutos). Instalações
+           novas deletam backups h264/ automaticamente após 5 min.
+           Configurável via config.yaml.
 
-  [LOG] Diagnóstico melhorado: quando o download falha sem .partial,
-        o log agora indica explicitamente "No partial file to keep".
-        Quando um partial é descartado por ser stale, o motivo é logado.
+  [LOG] melhor diagnóstico de resume: mostra % do partial, avisa quando
+        partial não existe, mostra path completo do partial mantido.
 
 --------------------------------------------------------------------------------
 

--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,30 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versão: 6.8.8
+Data: 08/06/2026
+--------------------------------------------------------------------------------
+
+Fix: dispatcher despachava RETRY_WAIT sem esperar backoff — resume não funcionava
+
+  [BUG] O dispatcher incluía RETRY_WAIT nos estados de download, despachando
+        jobs falhados imediatamente (~2s) em vez de respeitar o backoff
+        exponencial (10s→20s→40s→...). Isso fazia o resume nunca funcionar:
+        o job era re-despachado tão rápido que o .partial não era encontrado
+        pelo próximo worker.
+
+  [FIX] Removido RETRY_WAIT de DOWNLOAD_STATES no dispatcher. Agora apenas
+        o watchdog transiciona RETRY_WAIT → NEW após o delay correto.
+        O download resume agora funciona como projetado: o .partial é
+        preservado, o backoff é respeitado, e o próximo worker encontra
+        o arquivo parcial e continua de onde parou.
+
+  [LOG] Diagnóstico melhorado: quando o download falha sem .partial,
+        o log agora indica explicitamente "No partial file to keep".
+        Quando um partial é descartado por ser stale, o motivo é logado.
+
+--------------------------------------------------------------------------------
+
 Versão: 6.8.7
 Data: 05/06/2026
 --------------------------------------------------------------------------------

--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,22 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versão: 6.8.9
+Data: 08/06/2026
+--------------------------------------------------------------------------------
+
+Limpeza automática de staging — impede acúmulo de TB em disco
+
+  [FIX] staging acumulava arquivos de jobs falhados indefinidamente (2+ TB
+        no disco de produção). Agora todos os workers (download, transcode,
+        upload) limpam o staging dir quando um job atinge FAILED (max retries).
+
+  [NEW] self-health agent agora limpa staging dirs órfãos a cada 3h:
+        escaneia job_* dirs cujo job está em estado terminal (DONE, FAILED,
+        SKIPPED_*) ou não existe mais no banco. Libera disco automaticamente.
+
+--------------------------------------------------------------------------------
+
 Versão: 6.8.8
 Data: 08/06/2026
 --------------------------------------------------------------------------------

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "6.8.7"
+#define MyAppVersion "6.8.8"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "6.8.8"
+#define MyAppVersion "6.8.9"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v6.8.7 Installer
+# HeavyDrops Transcoder v6.8.8 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v6.8.7 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v6.8.8 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v6.8.7
+title HeavyDrops Transcoder v6.8.8
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v6.8.7
+echo   HeavyDrops Transcoder v6.8.8
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v6.8.7"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v6.8.8"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v6.8.7" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v6.8.8" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v6.8.7"
+$Shortcut.Description = "HeavyDrops Transcoder v6.8.8"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v6.8.8 Installer
+# HeavyDrops Transcoder v6.8.9 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v6.8.8 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v6.8.9 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v6.8.8
+title HeavyDrops Transcoder v6.8.9
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v6.8.8
+echo   HeavyDrops Transcoder v6.8.9
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v6.8.8"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v6.8.9"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v6.8.8" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v6.8.9" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v6.8.8"
+$Shortcut.Description = "HeavyDrops Transcoder v6.8.9"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "6.8.7"
+version = "6.8.8"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "6.8.8"
+version = "6.8.9"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "6.8.8"
+__version__ = "6.8.9"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "6.8.3"
+__version__ = "6.8.8"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/config.py
+++ b/src/transcoder/config.py
@@ -661,12 +661,12 @@ class Config(BaseModel):
         ),
     )
     legacy_reorganize_delete_h264_after_seconds: int = Field(
-        default=0,
+        default=300,
         ge=0,
         description=(
             "After a per-folder reorganize batch succeeds, schedule deletion "
             "of the <parent>/h264/ backup folder this many seconds later. "
-            "0 disables deletion (default — keep backups). Dropbox keeps "
+            "0 disables deletion (keep backups forever). Dropbox keeps "
             "deleted files in its history for 30 days (Plus) or 180 days "
             "(Business), so this is recoverable."
         ),

--- a/src/transcoder/dispatcher.py
+++ b/src/transcoder/dispatcher.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 # Which DB states feed which worker queue.
-DOWNLOAD_STATES = {JobState.NEW, JobState.RETRY_WAIT}
+DOWNLOAD_STATES = {JobState.NEW}
 TRANSCODE_STATES = {JobState.DOWNLOADED}
 UPLOAD_STATES = {JobState.UPLOADING}
 

--- a/src/transcoder/self_health.py
+++ b/src/transcoder/self_health.py
@@ -151,6 +151,7 @@ class SelfHealthAgent(threading.Thread):
         started = time.time()
         results: list[CheckResult] = [
             self._check_partials(),
+            self._check_orphan_staging(),
             self._check_stuck_jobs(),
             self._check_transcode_health(),
             self._check_disk_pressure(),
@@ -213,6 +214,44 @@ class SelfHealthAgent(threading.Thread):
                 actions_taken=actions,
             )
         return CheckResult("partials", True, "no stale partials")
+
+    def _check_orphan_staging(self) -> CheckResult:
+        """Remove staging job_* dirs whose jobs are in terminal or FAILED state."""
+        from .database import TERMINAL_STATES, JobState
+        staging = Path(self.config.local_staging_dir)
+        if not staging.exists():
+            return CheckResult("orphan-staging", True, "staging dir missing — skipping")
+
+        removable_states = TERMINAL_STATES | {JobState.FAILED}
+        removed = 0
+        bytes_freed = 0
+        actions = []
+        for d in staging.iterdir():
+            if not d.is_dir() or not d.name.startswith("job_"):
+                continue
+            try:
+                job_id = int(d.name.split("_", 1)[1])
+            except (ValueError, IndexError):
+                continue
+            job = self.db.get_job(job_id)
+            if job is None or job.state in removable_states:
+                try:
+                    dir_size = sum(f.stat().st_size for f in d.rglob("*") if f.is_file())
+                    shutil.rmtree(d)
+                    removed += 1
+                    bytes_freed += dir_size
+                    state_info = job.state if job else "missing"
+                    actions.append(f"removed {d.name} ({_fmt_bytes(dir_size)}, state={state_info})")
+                except Exception as e:
+                    actions.append(f"could not remove {d.name}: {e}")
+
+        if removed:
+            return CheckResult(
+                "orphan-staging", True,
+                f"cleaned {removed} orphan staging dir(s) ({_fmt_bytes(bytes_freed)})",
+                actions_taken=actions,
+            )
+        return CheckResult("orphan-staging", True, "no orphan staging dirs")
 
     def _check_stuck_jobs(self) -> CheckResult:
         """Jobs in DOWNLOADING/TRANSCODING/UPLOADING for >6h with no recent

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -284,8 +284,8 @@ class DownloadWorker(BaseWorker):
             if partial_size > 0 and (not expected or partial_size < expected):
                 logger.info(
                     f"[{self.name}] Resumable partial found: "
-                    f"{format_bytes(partial_size)} of {format_bytes(expected)} "
-                    f"({partial_size / expected * 100:.1f}%)" if expected else ""
+                    f"{format_bytes(partial_size)} of {format_bytes(expected)}"
+                    + (f" ({partial_size / expected * 100:.1f}%)" if expected else "")
                 )
             else:
                 logger.info(
@@ -344,9 +344,6 @@ class DownloadWorker(BaseWorker):
                 partial_path.unlink()
             raise
         except Exception:
-            # Retryable errors (IncompleteRead, timeout, network).
-            # Keep the partial so the next attempt resumes via Range header
-            # instead of re-downloading from zero.
             if partial_path.exists():
                 sz = partial_path.stat().st_size
                 logger.info(

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -521,6 +521,7 @@ class DownloadWorker(BaseWorker):
                 JobState.FAILED,
                 error_message=f"Max retries exceeded: {error}",
             )
+            self._cleanup_staging_on_failure(job)
         else:
             # Exponential backoff delay
             delay = min(300, 5 * (2 ** retry_count))
@@ -530,6 +531,19 @@ class DownloadWorker(BaseWorker):
                 error_message=f"Retry {retry_count}: {error}",
             )
             logger.info(f"[{self.name}] Will retry job {job.id} in {delay}s")
+
+    def _cleanup_staging_on_failure(self, job: Job) -> None:
+        """Remove staging dir when a download job reaches terminal FAILED state."""
+        original_name = Path(job.dropbox_path).name
+        job_dir, _, _ = get_staging_paths(
+            self.config.local_staging_dir, job.id, original_name,
+        )
+        if job_dir.exists() and job_dir.name.startswith('job_'):
+            try:
+                shutil.rmtree(job_dir)
+                logger.info(f"[{self.name}] Cleaned staging for FAILED job {job.id}: {job_dir}")
+            except Exception as e:
+                logger.warning(f"[{self.name}] Could not clean staging for job {job.id}: {e}")
 
 
 class TranscodeWorker(BaseWorker):
@@ -1066,8 +1080,13 @@ class TranscodeWorker(BaseWorker):
                 JobState.FAILED,
                 error_message=f"Max retries exceeded: {error}",
             )
-            if self.disk_budget is not None:
-                self.disk_budget.release(job.id)
+            try:
+                self._cleanup_staging(job)
+            except Exception as cleanup_err:
+                logger.debug(
+                    f"[{self.name}] staging cleanup after FAILED "
+                    f"failed (non-fatal): {cleanup_err}"
+                )
         else:
             self.db.update_job_state(
                 job.id,
@@ -1521,8 +1540,13 @@ class UploadWorker(BaseWorker):
                 JobState.FAILED,
                 error_message=f"Upload failed after retries: {error}",
             )
-            if self.disk_budget is not None:
-                self.disk_budget.release(job.id)
+            try:
+                self._cleanup_staging(job)
+            except Exception as cleanup_err:
+                logger.debug(
+                    f"[{self.name}] staging cleanup after FAILED "
+                    f"failed (non-fatal): {cleanup_err}"
+                )
         else:
             # Stay in UPLOADING state for retry
             self.db.update_job_state(

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -284,9 +284,14 @@ class DownloadWorker(BaseWorker):
             if partial_size > 0 and (not expected or partial_size < expected):
                 logger.info(
                     f"[{self.name}] Resumable partial found: "
-                    f"{format_bytes(partial_size)} of {format_bytes(expected)}"
+                    f"{format_bytes(partial_size)} of {format_bytes(expected)} "
+                    f"({partial_size / expected * 100:.1f}%)" if expected else ""
                 )
             else:
+                logger.info(
+                    f"[{self.name}] Discarding stale partial "
+                    f"({format_bytes(partial_size)} vs expected {format_bytes(expected)})"
+                )
                 try:
                     partial_path.unlink()
                 except OSError:
@@ -343,9 +348,15 @@ class DownloadWorker(BaseWorker):
             # Keep the partial so the next attempt resumes via Range header
             # instead of re-downloading from zero.
             if partial_path.exists():
+                sz = partial_path.stat().st_size
                 logger.info(
                     f"[{self.name}] Keeping partial "
-                    f"({format_bytes(partial_path.stat().st_size)}) for resume"
+                    f"({format_bytes(sz)}) for resume: {partial_path}"
+                )
+            else:
+                logger.warning(
+                    f"[{self.name}] No partial file to keep at {partial_path} "
+                    f"(download may have failed before writing any data)"
                 )
             raise
 

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v6.8.8
+HeavyDrops Transcoder v6.8.9
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "6.8.8"
+VERSION = "6.8.9"
 
 import socket
 import subprocess

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v6.8.7
+HeavyDrops Transcoder v6.8.8
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "6.8.7"
+VERSION = "6.8.8"
 
 import socket
 import subprocess


### PR DESCRIPTION
## Problema

O staging acumulou 2+ TB de arquivos órfãos de jobs falhados que nunca eram limpos. Arquivos enormes (32-46 GB) que falhavam repetidamente deixavam cópias no staging para sempre.

## Fix

- Todos os workers (download, transcode, upload) agora limpam o `job_*` staging dir quando um job atinge FAILED (max retries excedido).
- Novo `_check_orphan_staging` no self-health agent: a cada 3h escaneia o staging e remove dirs cujo job está em estado terminal (DONE, SKIPPED_*, FAILED) ou não existe mais no banco.

Version bump 6.8.8 → 6.8.9.

https://claude.ai/code/session_01GaPH9NsWSRKg1ZGWW7ecW5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPH9NsWSRKg1ZGWW7ecW5)_