### PR TITLE
v7.0.0: throughput pass — remove pipeline bottlenecks

### DIFF
--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,11 +2,11 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
-Versão: 6.8.10
+Versão: 7.0.0
 Data: 08/06/2026
 --------------------------------------------------------------------------------
 
-Sticky folder desligado por padrão — usa todos os download workers
+Throughput pass — remove gargalos do pipeline
 
   [CHANGE] dispatcher.sticky_folder_enabled mudou de True para False.
            Antes o dispatcher travava numa pasta e só baixava dela até
@@ -16,6 +16,24 @@ Sticky folder desligado por padrão — usa todos os download workers
            Agora usa folder-priority interleaving: sempre puxa de qualquer
            pasta e mantém todos os download workers ocupados.
            O reorganize continua funcionando pasta-por-pasta normalmente.
+
+  [PERF] novo índice composto idx_jobs_state_created (state, created_at).
+         A query de dispatch (WHERE state IN (...) ORDER BY created_at)
+         roda a cada ~2s; sem o índice composto o SQLite filtrava por
+         state e fazia um filesort em created_at toda vez. Agora resolve
+         tudo num passo só. Criado automaticamente no startup (IF NOT
+         EXISTS) — vale também pros bancos de produção já existentes.
+
+  [PERF] chunk de upload subiu de 4 MB para 16 MB. Saídas transcodadas
+         de vários GB faziam 4x mais round-trips HTTP que o necessário.
+         16 MB corta os round-trips mantendo o custo de retry por chunk
+         baixo numa conexão instável.
+
+  [REVIEW] convoy throttle e disk_budget foram auditados e mantidos: o
+           convoy só atua quando a fila de transcode está vazia (alimenta
+           a GPU mais rápido, ajuda o throughput ponta-a-ponta) e o
+           disk_budget libera o lock antes de dormir (não serializa os
+           workers). Nenhum dos dois é gargalo real.
 
 --------------------------------------------------------------------------------
 

--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,23 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versão: 6.8.10
+Data: 08/06/2026
+--------------------------------------------------------------------------------
+
+Sticky folder desligado por padrão — usa todos os download workers
+
+  [CHANGE] dispatcher.sticky_folder_enabled mudou de True para False.
+           Antes o dispatcher travava numa pasta e só baixava dela até
+           esvaziar — se a pasta tinha menos arquivos que download_workers,
+           os workers extras ficavam ociosos esperando. Ex: pasta com 2
+           arquivos = só 2 downloads, mesmo com 4 workers configurados.
+           Agora usa folder-priority interleaving: sempre puxa de qualquer
+           pasta e mantém todos os download workers ocupados.
+           O reorganize continua funcionando pasta-por-pasta normalmente.
+
+--------------------------------------------------------------------------------
+
 Versão: 6.8.9
 Data: 08/06/2026
 --------------------------------------------------------------------------------

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "6.8.10"
+#define MyAppVersion "7.0.0"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "6.8.9"
+#define MyAppVersion "6.8.10"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v6.8.10 Installer
+# HeavyDrops Transcoder v7.0.0 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v6.8.10 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.0.0 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v6.8.10
+title HeavyDrops Transcoder v7.0.0
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v6.8.10
+echo   HeavyDrops Transcoder v7.0.0
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v6.8.10"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.0.0"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v6.8.10" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.0.0" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v6.8.10"
+$Shortcut.Description = "HeavyDrops Transcoder v7.0.0"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v6.8.9 Installer
+# HeavyDrops Transcoder v6.8.10 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v6.8.9 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v6.8.10 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v6.8.9
+title HeavyDrops Transcoder v6.8.10
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v6.8.9
+echo   HeavyDrops Transcoder v6.8.10
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v6.8.9"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v6.8.10"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v6.8.9" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v6.8.10" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v6.8.9"
+$Shortcut.Description = "HeavyDrops Transcoder v6.8.10"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "6.8.10"
+version = "7.0.0"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "6.8.9"
+version = "6.8.10"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "6.8.10"
+__version__ = "7.0.0"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "6.8.9"
+__version__ = "6.8.10"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/config.py
+++ b/src/transcoder/config.py
@@ -285,16 +285,17 @@ class DispatcherSettings(BaseModel):
         ),
     )
     sticky_folder_enabled: bool = Field(
-        default=True,
+        default=False,
         description=(
             "When True, the dispatcher commits to draining one folder at a "
             "time: as long as any job from the 'sticky' folder is still in "
             "flight or dispatchable, no jobs from other folders are pulled "
             "into the download queue. Closes folders faster so the reorganize "
-            "cleanup batches fire and free up Dropbox quota sooner. Folder "
-            "priority (largest pending bytes first) still picks the next "
-            "sticky folder once the current one drains. Disable to fall back "
-            "to plain folder-priority interleaving."
+            "cleanup batches fire and free up Dropbox quota sooner — but it "
+            "bottlenecks download parallelism when the current folder has "
+            "fewer files than download_workers (idle workers wait for the "
+            "folder to drain). Default False: plain folder-priority "
+            "interleaving keeps every download worker busy across folders."
         ),
     )
 

--- a/src/transcoder/database.py
+++ b/src/transcoder/database.py
@@ -208,6 +208,11 @@ CREATE TABLE IF NOT EXISTS jobs (
 CREATE INDEX IF NOT EXISTS idx_jobs_state ON jobs(state);
 CREATE INDEX IF NOT EXISTS idx_jobs_path ON jobs(dropbox_path);
 CREATE INDEX IF NOT EXISTS idx_jobs_updated ON jobs(updated_at);
+-- Composite index for the hot dispatch query: get_dispatchable_jobs filters
+-- by state IN (...) and orders by created_at ASC every ~2s. Without
+-- (state, created_at) SQLite filters on idx_jobs_state then does a separate
+-- filesort on created_at each poll; this index serves both in one pass.
+CREATE INDEX IF NOT EXISTS idx_jobs_state_created ON jobs(state, created_at);
 
 -- One active row per dropbox_path: blocks duplicate queued/in-progress jobs
 -- when the same file is rediscovered between scans.

--- a/src/transcoder/dropbox_client.py
+++ b/src/transcoder/dropbox_client.py
@@ -199,8 +199,12 @@ class DropboxClient:
     Provides retry logic and error handling for common operations.
     """
 
-    CHUNK_SIZE = 4 * 1024 * 1024  # 4MB chunks for upload
-    DOWNLOAD_CHUNK_SIZE = 8 * 1024 * 1024  # 8MB chunks for download
+    # 16MB upload session chunks. Dropbox allows up to 150MB per
+    # files_upload_session_append_v2 call; 4MB was needlessly small and made
+    # multi-GB transcoded outputs do 4x the HTTP round-trips. 16MB keeps the
+    # per-chunk retry cost modest on a flaky link while cutting round-trips.
+    CHUNK_SIZE = 16 * 1024 * 1024  # 16MB chunks for upload
+    DOWNLOAD_CHUNK_SIZE = 8 * 1024 * 1024  # 8MB chunks for download (stream read buffer)
 
     def __init__(
         self,

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v6.8.10
+HeavyDrops Transcoder v7.0.0
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "6.8.10"
+VERSION = "7.0.0"
 
 import socket
 import subprocess

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v6.8.9
+HeavyDrops Transcoder v6.8.10
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "6.8.9"
+VERSION = "6.8.10"
 
 import socket
 import subprocess


### PR DESCRIPTION
## Resumo

Review do pipeline inteiro caçando gargalos de throughput. Três mudanças reais + auditoria dos mecanismos que *pareciam* gargalo mas não são.

## Mudanças

**1. Sticky folder desligado por padrão** (`sticky_folder_enabled: True → False`)
O dispatcher travava numa pasta e drenava ela inteira antes de pular pra próxima. Se a pasta tinha menos arquivos que `download_workers`, os workers extras ficavam ociosos. Ex.: pasta com 2 arquivos prendia só 2 de 4 workers. Agora usa folder-priority interleaving e mantém todos os workers ocupados. O reorganize per-folder continua igual.

**2. Índice composto `idx_jobs_state_created (state, created_at)`**
A query de dispatch (`WHERE state IN (...) ORDER BY created_at`) roda a cada ~2s. Sem o índice composto o SQLite filtrava por `state` e fazia um filesort em `created_at` toda vez. Criado no startup via `IF NOT EXISTS` — aplica automaticamente nos bancos de produção existentes no próximo restart.

**3. Chunk de upload 4 MB → 16 MB**
Saídas transcodadas de vários GB faziam 4× mais round-trips HTTP que o necessário. 16 MB corta os round-trips mantendo custo de retry por chunk baixo numa conexão instável.

## Auditado e mantido (não são gargalo real)

- **Convoy throttle**: só atua quando a fila de transcode está vazia — serve pra alimentar a GPU mais rápido, ajuda o throughput ponta-a-ponta.
- **disk_budget**: libera o lock antes de dormir (`wait_for_slot`), não serializa os workers. O relatório inicial classificou errado como HIGH.

https://claude.ai/code/session_01GaPH9NsWSRKg1ZGWW7ecW5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaPH9NsWSRKg1ZGWW7ecW5)_