### PR TITLE
v7.1.0: lift the per-100MB rev-check out of the download byte loop

### DIFF
--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,32 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versão: 7.1.0
+Data: 08/06/2026
+--------------------------------------------------------------------------------
+
+Download: tira o rev-check de dentro do loop de bytes
+
+  [PERF] novo knob download_rev_check_interval_mb (default 2048, antes era
+         fixo em 100 MB). O download_file_with_rev_check chamava
+         files_get_metadata SÍNCRONO a cada 100 MB no meio do loop de bytes
+         — num ISO de 47 GB isso eram ~470 round-trips ao Dropbox, cada um
+         travando o stream (e ainda uma superfície de falha a cada 100 MB,
+         possivelmente contribuindo pros IncompleteRead em arquivos longos).
+         Em pasta de arquivo morto (_arquivo mais de 30 dias) o arquivo nem
+         muda, então era custo puro. A correção NÃO mexe na segurança: o
+         scanner.verify_job_rev pós-download já detecta arquivo alterado no
+         meio do caminho e descarta o parcial. O check periódico só servia
+         pra bailar mais cedo. 2048 MB mantém esse fast-fail cortando ~95%
+         das chamadas; 0 desliga o check periódico de vez.
+
+  [CHANGE] check_interval_mb <= 0 agora desliga o check periódico de forma
+           limpa (antes, 0 disparava o check em TODO chunk por causa do
+           >= 0). Os checks finais de rev/tamanho continuam guardando a
+           correção independente do valor.
+
+--------------------------------------------------------------------------------
+
 Versão: 7.0.0
 Data: 08/06/2026
 --------------------------------------------------------------------------------

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -190,6 +190,12 @@ audio:
 # download to detect natively-encoded H.265 files via ffprobe. When detected,
 # the full download is skipped and the job is marked SKIPPED_HEVC. 0 disables.
 preflight_hevc_probe_mb: 16
+# During a download, re-check the Dropbox rev every N MB to fast-fail if the
+# source is overwritten mid-transfer. The post-download rev check already
+# guarantees correctness, so this is bandwidth-saving only. 2048 keeps the
+# fast-fail while avoiding the hundreds of synchronous metadata calls the old
+# 100 MB cadence made per multi-GB file. 0 disables the periodic check.
+download_rev_check_interval_mb: 2048
 allow_delete_original: false
 delete_original_delay_hours: 168
 allow_mkv_fallback: false

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.0.0"
+#define MyAppVersion "7.1.0"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.0.0 Installer
+# HeavyDrops Transcoder v7.1.0 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.0.0 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.1.0 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.0.0
+title HeavyDrops Transcoder v7.1.0
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.0.0
+echo   HeavyDrops Transcoder v7.1.0
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.0.0"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.1.0"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.0.0" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.1.0" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.0.0"
+$Shortcut.Description = "HeavyDrops Transcoder v7.1.0"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.0.0"
+version = "7.1.0"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.0.0"
+__version__ = "7.1.0"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/config.py
+++ b/src/transcoder/config.py
@@ -774,6 +774,22 @@ class Config(BaseModel):
             "exports without burning bandwidth."
         ),
     )
+    download_rev_check_interval_mb: int = Field(
+        default=2048,
+        ge=0,
+        description=(
+            "During a download, re-check the Dropbox file revision every N MB "
+            "to fast-fail if the source was modified mid-transfer. The "
+            "post-download rev check (scanner.verify_job_rev) already "
+            "guarantees correctness — a file changed mid-flight is detected and "
+            "the partial discarded — so this only saves bandwidth by bailing "
+            "early on the rare overwrite. The old 100 MB cadence fired a "
+            "synchronous metadata API call hundreds of times per multi-GB file "
+            "(~470 calls on a 47 GB ISO), stalling the byte stream for zero gain "
+            "on immutable archives. 2048 MB keeps the fast-fail while cutting "
+            "~95% of those calls. Set 0 to disable the periodic check entirely."
+        ),
+    )
 
     # GOP size
     gop_size: int = Field(

--- a/src/transcoder/dropbox_client.py
+++ b/src/transcoder/dropbox_client.py
@@ -645,7 +645,7 @@ class DropboxClient:
         local_path: Path,
         expected_rev: str,
         progress_callback: Callable[[int, int], None] | None = None,
-        check_interval_mb: int = 100,
+        check_interval_mb: int = 2048,
     ) -> str:
         """
         Download file with periodic revision checks and resume support.
@@ -659,7 +659,13 @@ class DropboxClient:
             local_path: Destination local path.
             expected_rev: Expected file revision.
             progress_callback: Optional callback(bytes_downloaded, total_bytes).
-            check_interval_mb: Check rev every N megabytes downloaded.
+            check_interval_mb: Re-check the source rev every N megabytes as a
+                fast-fail against a mid-download overwrite. Correctness does not
+                depend on it — the caller's post-download rev check catches a
+                changed file regardless — so this is a bandwidth optimization
+                only. 0 disables the periodic check (the final rev/size checks
+                still run). Keep it large (GBs) so multi-GB downloads don't fire
+                a synchronous metadata call every few seconds.
 
         Returns:
             The file revision.
@@ -742,8 +748,12 @@ class DropboxClient:
                             progress_callback(bytes_downloaded, total_size)
                         GOVERNOR.consume(len(chunk))
 
-                        # Periodic rev check
-                        if bytes_downloaded - last_check_bytes >= check_interval:
+                        # Periodic rev check (fast-fail on a mid-download
+                        # overwrite). check_interval <= 0 disables it entirely;
+                        # the final rev/size checks after the loop still guard
+                        # correctness either way.
+                        if check_interval > 0 and \
+                                bytes_downloaded - last_check_bytes >= check_interval:
                             current_metadata = self._dbx.files_get_metadata(norm_path)
                             if isinstance(current_metadata, FileMetadata):
                                 if current_metadata.rev != expected_rev:

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -311,6 +311,7 @@ class DownloadWorker(BaseWorker):
                 partial_path,
                 expected_rev=job.dropbox_rev,
                 progress_callback=self._make_progress_callback(job),
+                check_interval_mb=self.config.download_rev_check_interval_mb,
             )
 
             # Final rev check before committing

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.0.0
+HeavyDrops Transcoder v7.1.0
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.0.0"
+VERSION = "7.1.0"
 
 import socket
 import subprocess


### PR DESCRIPTION
## What

Removes a download-pipeline bottleneck found during a full hot-path review: `download_file_with_rev_check` re-checked the Dropbox file revision **every 100 MB from inside the byte loop** via a synchronous `files_get_metadata` call.

On the archive workload (`_arquivo mais de 30 dias`, files of 30–47 GB) that meant **~470 blocking Dropbox round-trips per file**, each stalling the transfer — for zero benefit, since those files never change. It was also an extra failure surface every 100 MB that may have contributed to the `IncompleteRead` drops seen on long downloads.

## Why it's safe

Correctness never depended on the periodic check. After the download finishes, `scanner.verify_job_rev` already re-checks the rev and discards the partial if the source changed mid-flight, and there's a final size check too. The mid-stream check only ever served to *bail early* on the rare mid-download overwrite.

## Change

- New config knob **`download_rev_check_interval_mb`** (default **2048**). Keeps the early-bail behaviour within ~2 GB while cutting ~95% of the metadata calls on multi-GB files. `0` disables the periodic check entirely.
- Wired through `DownloadWorker` → `download_file_with_rev_check`.
- Fixed an edge case: `check_interval <= 0` now disables the check cleanly (previously `0` would fire the check on *every* chunk via the `>= 0` comparison).
- Documented in `config.example.yaml`.
- Version bump **7.0.0 → 7.1.0** (pyproject + `__init__` + GUI + installer via `sync_version.py`; changelog entry added).

## Tests

- `tests/test_download_resume.py` (exercises `download_file_with_rev_check`) and `tests/test_version_sync.py` pass.
- Full suite: 56 passed. The 1 failure (`test_manifest_per_pc::test_cleanup_old_history`) is a **pre-existing, date-dependent time-bomb** unrelated to this change — confirmed it fails on the base tree too (hardcoded `2025-12-01` is now >90 days before the system date).

## Out of scope (from the same review, deferred per your call)

- Sticky-folder is ON in the running config (code default is now `false`) — serializes the 4 downloaders onto one folder. Config flip, not shipped here.
- NVENC dual-encoder idea: **N/A** — no NVIDIA card on this box (the `Detected NVIDIA NVENC` log line is a false positive; `encoder_detect` only greps `ffmpeg -encoders` build flags, not hardware).
- Latent footgun: deep-scan throttles the whole pipeline to 1 MB/s via `GOVERNOR` — don't run it during the bulk.

https://claude.ai/code/session_01C4rWMqR8dYHAU3dU4nU5Mx

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4rWMqR8dYHAU3dU4nU5Mx)_