### PR TITLE
v7.6.2: bake Dropbox credentials into the fleet install via env vars

### DIFF
--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,26 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versão: 7.6.2
+Data: 09/06/2026
+--------------------------------------------------------------------------------
+
+Credenciais do Dropbox por variável de ambiente (não repetir em 6 PCs)
+
+  [FEATURE] O bootstrap.ps1 agora lê as credenciais do Dropbox de variáveis de
+            ambiente, pra instalar a frota sem digitar o token em cada máquina:
+              - HD_DROPBOX_APP_KEY / HD_DROPBOX_APP_SECRET /
+                HD_DROPBOX_REFRESH_TOKEN  → auth durável (recomendado; o token
+                simples expira em ~4h e a daemon morre)
+              - HD_DROPBOX_TOKEN  → token de acesso legado (curta duração)
+            As credenciais vão no COMANDO que você cola (mesma linha nos 6 PCs)
+            e são gravadas só no config.yaml LOCAL — NUNCA no repositório.
+            Copie os 3 valores do config.yaml de uma máquina que já funciona
+            (ex.: HEAVY7). Se nenhuma env var estiver setada, ele pergunta como
+            antes.
+
+--------------------------------------------------------------------------------
+
 Versão: 7.6.1
 Data: 09/06/2026
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ $env:HD_WORKER=1; iwr https://raw.githubusercontent.com/luisimperator/rep01/main
 
 Same one command — it just applies the production profile (`installer/apply_worker_profile.py`) on top of the normal install. Point every machine at the **same Dropbox account/folder and claims folder**, and roll out on one machine first. Everything is adjustable afterwards from the dashboard's **Settings → Fleet** section — no files to edit.
 
+To avoid retyping the Dropbox credentials on each of the 6 machines, bake them into the command (they go into the pasted command, **never into the repo**). Use the durable refresh-token trio — copy `dropbox_app_key`, `dropbox_app_secret`, and `dropbox_refresh_token` from a working machine's `config.yaml` (e.g. HEAVY7); a plain access token expires in ~4 h:
+
+```powershell
+$env:HD_WORKER=1
+$env:HD_DROPBOX_APP_KEY='...'; $env:HD_DROPBOX_APP_SECRET='...'; $env:HD_DROPBOX_REFRESH_TOKEN='...'
+iwr https://raw.githubusercontent.com/luisimperator/rep01/main/bootstrap.ps1 -UseBasicParsing | iex
+```
+
+The bootstrap also reads `HD_DROPBOX_TOKEN` for the legacy short-lived token. Credentials are written only to the machine's local `config.yaml`, never committed.
+
 To apply a new release later:
 
 ```powershell

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -11,6 +11,15 @@
 #
 #   $env:HD_WORKER=1; iwr https://raw.githubusercontent.com/luisimperator/rep01/main/bootstrap.ps1 -UseBasicParsing | iex
 #
+# To also bake in the Dropbox credentials so you don't retype them on every
+# machine, set them too — they go into the command you paste, NEVER into the
+# repo. Use the durable refresh-token trio (copy the three values from a working
+# machine's config.yaml, e.g. HEAVY7); a plain access token expires in ~4h:
+#
+#   $env:HD_WORKER=1
+#   $env:HD_DROPBOX_APP_KEY='...'; $env:HD_DROPBOX_APP_SECRET='...'; $env:HD_DROPBOX_REFRESH_TOKEN='...'
+#   iwr https://raw.githubusercontent.com/luisimperator/rep01/main/bootstrap.ps1 -UseBasicParsing | iex
+#
 # What it does:
 #   1. Ensures Git and Python 3.12 are installed (via winget, user scope).
 #   2. Clones this repo to %USERPROFILE%\HeavyDrops (or updates if it already exists).
@@ -142,7 +151,15 @@ if (-not (Test-Path $ExampleConfig)) {
 
 if (-not (Test-Path $ConfigPath)) {
     Info "Writing config.yaml..."
-    $token = Read-Host 'Paste your Dropbox access token (leave blank to set later)'
+    if ($env:HD_DROPBOX_TOKEN) {
+        $token = $env:HD_DROPBOX_TOKEN
+        Info "Using Dropbox access token from HD_DROPBOX_TOKEN."
+    } elseif ($env:HD_DROPBOX_REFRESH_TOKEN) {
+        $token = ''   # durable refresh-token auth set below; no short-lived token needed
+        Info "Using Dropbox refresh-token credentials from HD_DROPBOX_* env vars."
+    } else {
+        $token = Read-Host 'Paste your Dropbox access token (leave blank to set later)'
+    }
     $raw = Get-Content -Raw -LiteralPath $ExampleConfig
 
     # User-scoped paths
@@ -155,6 +172,17 @@ if (-not (Test-Path $ConfigPath)) {
     $raw = $raw -replace 'ffprobe_path: .*',      ('ffprobe_path: "'      + $FFprobeExe.Replace('\','/') + '"')
     if ($token) {
         $raw = $raw -replace 'dropbox_token: .*', ("dropbox_token: `"$token`"")
+    }
+    # Durable refresh-token auth (recommended — short-lived tokens die in ~4h).
+    # Copy these three values from a working machine's config.yaml (e.g. HEAVY7).
+    if ($env:HD_DROPBOX_APP_KEY) {
+        $raw = $raw -replace 'dropbox_app_key: .*', ("dropbox_app_key: `"$($env:HD_DROPBOX_APP_KEY)`"")
+    }
+    if ($env:HD_DROPBOX_APP_SECRET) {
+        $raw = $raw -replace 'dropbox_app_secret: .*', ("dropbox_app_secret: `"$($env:HD_DROPBOX_APP_SECRET)`"")
+    }
+    if ($env:HD_DROPBOX_REFRESH_TOKEN) {
+        $raw = $raw -replace 'dropbox_refresh_token: .*', ("dropbox_refresh_token: `"$($env:HD_DROPBOX_REFRESH_TOKEN)`"")
     }
 
     Set-Content -LiteralPath $ConfigPath -Value $raw -Encoding UTF8

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.6.1"
+#define MyAppVersion "7.6.2"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.6.1 Installer
+# HeavyDrops Transcoder v7.6.2 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.1 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.2 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.6.1
+title HeavyDrops Transcoder v7.6.2
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.6.1
+echo   HeavyDrops Transcoder v7.6.2
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.1"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.2"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.1" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.2" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.6.1"
+$Shortcut.Description = "HeavyDrops Transcoder v7.6.2"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.6.1"
+version = "7.6.2"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.6.1"
+__version__ = "7.6.2"
 __author__ = "Dropbox Video Transcoder Team"

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.6.1
+HeavyDrops Transcoder v7.6.2
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.6.1"
+VERSION = "7.6.2"
 
 import socket
 import subprocess


### PR DESCRIPTION
Installing the 6 editor machines shouldn't mean pasting the Dropbox token six times.

`bootstrap.ps1` now reads Dropbox credentials from environment variables set in the pasted command, so the **same one-liner works on every machine** and the secret **never touches the repo** (it's written only to each machine's local `config.yaml`):

- `HD_DROPBOX_APP_KEY` / `HD_DROPBOX_APP_SECRET` / `HD_DROPBOX_REFRESH_TOKEN` — durable refresh-token auth (recommended; a plain access token expires in ~4h and the daemon dies). Copy the three values from a working machine's `config.yaml` (e.g. HEAVY7).
- `HD_DROPBOX_TOKEN` — legacy short-lived access token.

Falls back to the interactive prompt when nothing is set. README + bootstrap header document the credential one-liner.

Verified by simulating the bootstrap substitutions: the refresh-token trio lands in config and `has_dropbox_auth()` returns True. Full suite green except the pre-existing date time-bomb (`test_cleanup_old_history`).

https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa)_