### PR TITLE
v7.6.3: fix bootstrap.ps1 parse error on Windows PowerShell (em-dashes)

### DIFF
--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,19 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versao: 7.6.3
+Data: 09/06/2026
+--------------------------------------------------------------------------------
+
+Fix: bootstrap.ps1 quebrava no Windows PowerShell (travessao)
+
+  [FIX] O bootstrap.ps1 usava travessoes (em-dash) nas mensagens. O Windows
+        PowerShell le .ps1 como Windows-1252 (sem BOM), entao o em-dash virava
+        bytes com aspas no meio e quebrava a string ("missing terminator").
+        Agora o script e ASCII puro - instala sem erro de parse.
+
+--------------------------------------------------------------------------------
+
 Versão: 7.6.2
 Data: 09/06/2026
 --------------------------------------------------------------------------------

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,18 +1,18 @@
-# HeavyDrops Transcoder — Windows one-liner bootstrap.
+# HeavyDrops Transcoder - Windows one-liner bootstrap.
 #
 # Usage (paste into PowerShell):
 #
 #   iwr https://raw.githubusercontent.com/luisimperator/rep01/main/bootstrap.ps1 -UseBasicParsing | iex
 #
-# For an EDITORS' machine (Heavy1-6) that should only chip in OVERNIGHT —
+# For an EDITORS' machine (Heavy1-6) that should only chip in OVERNIGHT -
 # pre-configured for NVIDIA NVENC, night mode (18:00-09:00, yields the instant
-# someone uses the PC), shared-Dropbox claim, and a low disk footprint — set
+# someone uses the PC), shared-Dropbox claim, and a low disk footprint - set
 # HD_WORKER first:
 #
 #   $env:HD_WORKER=1; iwr https://raw.githubusercontent.com/luisimperator/rep01/main/bootstrap.ps1 -UseBasicParsing | iex
 #
 # To also bake in the Dropbox credentials so you don't retype them on every
-# machine, set them too — they go into the command you paste, NEVER into the
+# machine, set them too - they go into the command you paste, NEVER into the
 # repo. Use the durable refresh-token trio (copy the three values from a working
 # machine's config.yaml, e.g. HEAVY7); a plain access token expires in ~4h:
 #
@@ -173,7 +173,7 @@ if (-not (Test-Path $ConfigPath)) {
     if ($token) {
         $raw = $raw -replace 'dropbox_token: .*', ("dropbox_token: `"$token`"")
     }
-    # Durable refresh-token auth (recommended — short-lived tokens die in ~4h).
+    # Durable refresh-token auth (recommended - short-lived tokens die in ~4h).
     # Copy these three values from a working machine's config.yaml (e.g. HEAVY7).
     if ($env:HD_DROPBOX_APP_KEY) {
         $raw = $raw -replace 'dropbox_app_key: .*', ("dropbox_app_key: `"$($env:HD_DROPBOX_APP_KEY)`"")
@@ -252,10 +252,10 @@ Info ""
 if ($WorkerMode) {
     Info "This machine is set up as a NIGHT WORKER:"
     Info "  - encodes only 18:00-09:00, and pauses the instant someone uses it"
-    Info "  - shares the Dropbox pool (no duplicate work) — same claims folder as the others"
+    Info "  - shares the Dropbox pool (no duplicate work) - same claims folder as the others"
     Info "  - NVIDIA NVENC, low disk footprint"
     Info "  Make sure it points at the SAME Dropbox account/folder as the dedicated box."
-    Info "  Tweak anything from the dashboard's Settings > Fleet section — no files to edit."
+    Info "  Tweak anything from the dashboard's Settings > Fleet section - no files to edit."
     Info ""
 }
 Info "The daemon auto-starts at each logon. To stop or restart now:"

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.6.2"
+#define MyAppVersion "7.6.3"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.6.2 Installer
+# HeavyDrops Transcoder v7.6.3 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.2 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.3 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.6.2
+title HeavyDrops Transcoder v7.6.3
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.6.2
+echo   HeavyDrops Transcoder v7.6.3
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.2"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.3"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.2" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.3" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.6.2"
+$Shortcut.Description = "HeavyDrops Transcoder v7.6.3"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.6.2"
+version = "7.6.3"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.6.2"
+__version__ = "7.6.3"
 __author__ = "Dropbox Video Transcoder Team"

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.6.2
+HeavyDrops Transcoder v7.6.3
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.6.2"
+VERSION = "7.6.3"
 
 import socket
 import subprocess


### PR DESCRIPTION
`bootstrap.ps1` used em-dashes (—) in its `Info "..."` messages. Windows PowerShell reads a BOM-less `.ps1` as Windows-1252, so each em-dash decoded to bytes containing a double-quote, prematurely terminating the string and aborting the whole script at parse time with *"The string is missing the terminator"* / *"Missing closing '}'"* — so the install never ran.

The script is now pure ASCII and parses under any code page. `install.ps1` verified ASCII-clean too.

Urgent: `main` currently carries the broken bootstrap (the em-dashes shipped with the worker-mode messages in v7.6.1), so this needs to land on main for the one-liner to work.

https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa)_