### PR TITLE
v7.6.4–7.6.6: put worker scratch on the big drive (D:), keep the dedicated box on C:

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ To avoid retyping the Dropbox credentials on each of the 6 machines, bake them i
 
 ```powershell
 $env:HD_WORKER=1
+$env:HD_DATA_DIR='D:\HeavyDrops-data'
 $env:HD_DROPBOX_APP_KEY='...'; $env:HD_DROPBOX_APP_SECRET='...'; $env:HD_DROPBOX_REFRESH_TOKEN='...'
 iwr https://raw.githubusercontent.com/luisimperator/rep01/main/bootstrap.ps1 -UseBasicParsing | iex
 ```
 
-The bootstrap also reads `HD_DROPBOX_TOKEN` for the legacy short-lived token. Credentials are written only to the machine's local `config.yaml`, never committed.
+`HD_DATA_DIR` forces where the scratch/data (downloads, transcodes, DB, logs) live — point it at the big drive (e.g. `D:`) so it never fills the small system disk. If unset, the installer auto-picks the largest non-system fixed drive. The bootstrap also reads `HD_DROPBOX_TOKEN` for the legacy short-lived token. Credentials are written only to the machine's local `config.yaml`, never committed.
 
 To apply a new release later:
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -65,12 +65,12 @@ function Info([string]$msg)  { Write-Host "[bootstrap] $msg" -ForegroundColor Cy
 function Warn([string]$msg)  { Write-Host "[bootstrap] $msg" -ForegroundColor Yellow }
 function Die([string]$msg)   { Write-Host "[bootstrap] $msg" -ForegroundColor Red; exit 1 }
 
-# --- Put scratch/data on the largest fixed drive --------------------------
-# The transcoder stages multi-GB downloads on disk. On editors' machines the
-# system drive (C:) is small/often full, so move the data dir (staging, output,
-# DB, logs) to the LARGEST non-system fixed drive (e.g. the 2 TB D:). The code
-# and venv stay small under the profile. Falls back to the profile if anything
-# goes wrong. The disk_budget min-free guard still protects the editors' space.
+# --- Choose where scratch/data (staging, output, DB, logs) lives ----------
+# Priority: 1) explicit HD_DATA_DIR, 2) on WORKER machines only, the largest
+# non-system fixed drive (e.g. the 2 TB D:, since the editors' C: is small/full),
+# 3) otherwise the profile drive. The dedicated box (no worker mode) therefore
+# stays on C: as before. Code + venv always stay small under the profile, and
+# the disk_budget min-free guard still protects the editors' space.
 try {
     if ($env:HD_DATA_DIR) {
         $DataDir  = $env:HD_DATA_DIR
@@ -79,7 +79,8 @@ try {
         $StageDir = Join-Path $DataDir 'staging'
         Info "Scratch/data dir set from HD_DATA_DIR: $DataDir"
     }
-    elseif (($biggest = Get-CimInstance Win32_LogicalDisk -Filter 'DriveType=3' -ErrorAction Stop |
+    elseif ($WorkerMode -and
+            ($biggest = Get-CimInstance Win32_LogicalDisk -Filter 'DriveType=3' -ErrorAction Stop |
                Sort-Object Size -Descending | Select-Object -First 1) -and
             $biggest.DeviceID -and $biggest.DeviceID -ne $env:SystemDrive) {
         $candidate = Join-Path ($biggest.DeviceID + '\') 'HeavyDrops-data'
@@ -91,7 +92,8 @@ try {
               $biggest.DeviceID, [math]::Round($biggest.Size / 1GB), $DataDir)
     }
     else {
-        Info "Largest drive is the system drive; keeping data under the profile."
+        # Dedicated box (no worker mode) keeps its data under the profile (C:).
+        Info "Keeping data under the profile: $DataDir"
     }
 } catch {
     Warn "Could not place data on the chosen drive; using $DataDir"

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -17,8 +17,13 @@
 # machine's config.yaml, e.g. HEAVY7); a plain access token expires in ~4h:
 #
 #   $env:HD_WORKER=1
+#   $env:HD_DATA_DIR='D:\HeavyDrops-data'   # put the scratch/data on the big drive
 #   $env:HD_DROPBOX_APP_KEY='...'; $env:HD_DROPBOX_APP_SECRET='...'; $env:HD_DROPBOX_REFRESH_TOKEN='...'
 #   iwr https://raw.githubusercontent.com/luisimperator/rep01/main/bootstrap.ps1 -UseBasicParsing | iex
+#
+# HD_DATA_DIR forces where downloads/transcodes/db/logs live. If unset, the
+# installer auto-picks the largest non-system drive. Code + venv stay small
+# under %USERPROFILE%.
 #
 # What it does:
 #   1. Ensures Git and Python 3.12 are installed (via winget, user scope).
@@ -67,9 +72,16 @@ function Die([string]$msg)   { Write-Host "[bootstrap] $msg" -ForegroundColor Re
 # and venv stay small under the profile. Falls back to the profile if anything
 # goes wrong. The disk_budget min-free guard still protects the editors' space.
 try {
-    $biggest = Get-CimInstance Win32_LogicalDisk -Filter 'DriveType=3' -ErrorAction Stop |
-               Sort-Object Size -Descending | Select-Object -First 1
-    if ($biggest -and $biggest.DeviceID -and $biggest.DeviceID -ne $env:SystemDrive) {
+    if ($env:HD_DATA_DIR) {
+        $DataDir  = $env:HD_DATA_DIR
+        New-Item -ItemType Directory -Force -Path $DataDir -ErrorAction Stop | Out-Null
+        $LogDir   = Join-Path $DataDir 'logs'
+        $StageDir = Join-Path $DataDir 'staging'
+        Info "Scratch/data dir set from HD_DATA_DIR: $DataDir"
+    }
+    elseif (($biggest = Get-CimInstance Win32_LogicalDisk -Filter 'DriveType=3' -ErrorAction Stop |
+               Sort-Object Size -Descending | Select-Object -First 1) -and
+            $biggest.DeviceID -and $biggest.DeviceID -ne $env:SystemDrive) {
         $candidate = Join-Path ($biggest.DeviceID + '\') 'HeavyDrops-data'
         New-Item -ItemType Directory -Force -Path $candidate -ErrorAction Stop | Out-Null
         $DataDir  = $candidate
@@ -77,11 +89,12 @@ try {
         $StageDir = Join-Path $DataDir 'staging'
         Info ("Scratch/data on largest drive {0} ({1} GB): {2}" -f `
               $biggest.DeviceID, [math]::Round($biggest.Size / 1GB), $DataDir)
-    } else {
+    }
+    else {
         Info "Largest drive is the system drive; keeping data under the profile."
     }
 } catch {
-    Warn "Could not place data on the largest drive; using $DataDir"
+    Warn "Could not place data on the chosen drive; using $DataDir"
 }
 
 # --- 1. Prerequisites -----------------------------------------------------

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -60,6 +60,30 @@ function Info([string]$msg)  { Write-Host "[bootstrap] $msg" -ForegroundColor Cy
 function Warn([string]$msg)  { Write-Host "[bootstrap] $msg" -ForegroundColor Yellow }
 function Die([string]$msg)   { Write-Host "[bootstrap] $msg" -ForegroundColor Red; exit 1 }
 
+# --- Put scratch/data on the largest fixed drive --------------------------
+# The transcoder stages multi-GB downloads on disk. On editors' machines the
+# system drive (C:) is small/often full, so move the data dir (staging, output,
+# DB, logs) to the LARGEST non-system fixed drive (e.g. the 2 TB D:). The code
+# and venv stay small under the profile. Falls back to the profile if anything
+# goes wrong. The disk_budget min-free guard still protects the editors' space.
+try {
+    $biggest = Get-CimInstance Win32_LogicalDisk -Filter 'DriveType=3' -ErrorAction Stop |
+               Sort-Object Size -Descending | Select-Object -First 1
+    if ($biggest -and $biggest.DeviceID -and $biggest.DeviceID -ne $env:SystemDrive) {
+        $candidate = Join-Path ($biggest.DeviceID + '\') 'HeavyDrops-data'
+        New-Item -ItemType Directory -Force -Path $candidate -ErrorAction Stop | Out-Null
+        $DataDir  = $candidate
+        $LogDir   = Join-Path $DataDir 'logs'
+        $StageDir = Join-Path $DataDir 'staging'
+        Info ("Scratch/data on largest drive {0} ({1} GB): {2}" -f `
+              $biggest.DeviceID, [math]::Round($biggest.Size / 1GB), $DataDir)
+    } else {
+        Info "Largest drive is the system drive; keeping data under the profile."
+    }
+} catch {
+    Warn "Could not place data on the largest drive; using $DataDir"
+}
+
 # --- 1. Prerequisites -----------------------------------------------------
 
 function Ensure-Tool([string]$exe, [string]$wingetId, [string]$label) {

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.6.4"
+#define MyAppVersion "7.6.5"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.6.5"
+#define MyAppVersion "7.6.6"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.6.3"
+#define MyAppVersion "7.6.4"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.6.4 Installer
+# HeavyDrops Transcoder v7.6.5 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.4 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.5 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.6.4
+title HeavyDrops Transcoder v7.6.5
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.6.4
+echo   HeavyDrops Transcoder v7.6.5
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.4"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.5"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.4" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.5" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.6.4"
+$Shortcut.Description = "HeavyDrops Transcoder v7.6.5"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.6.3 Installer
+# HeavyDrops Transcoder v7.6.4 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.3 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.4 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.6.3
+title HeavyDrops Transcoder v7.6.4
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.6.3
+echo   HeavyDrops Transcoder v7.6.4
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.3"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.4"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.3" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.4" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.6.3"
+$Shortcut.Description = "HeavyDrops Transcoder v7.6.4"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.6.5 Installer
+# HeavyDrops Transcoder v7.6.6 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.5 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.6 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.6.5
+title HeavyDrops Transcoder v7.6.6
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.6.5
+echo   HeavyDrops Transcoder v7.6.6
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.5"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.6"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.5" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.6" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.6.5"
+$Shortcut.Description = "HeavyDrops Transcoder v7.6.6"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.6.3"
+version = "7.6.4"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.6.5"
+version = "7.6.6"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.6.4"
+version = "7.6.5"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.6.5"
+__version__ = "7.6.6"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.6.4"
+__version__ = "7.6.5"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.6.3"
+__version__ = "7.6.4"
 __author__ = "Dropbox Video Transcoder Team"

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.6.4
+HeavyDrops Transcoder v7.6.5
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.6.4"
+VERSION = "7.6.5"
 
 import socket
 import subprocess

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.6.5
+HeavyDrops Transcoder v7.6.6
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.6.5"
+VERSION = "7.6.6"
 
 import socket
 import subprocess

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.6.3
+HeavyDrops Transcoder v7.6.4
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.6.3"
+VERSION = "7.6.4"
 
 import socket
 import subprocess


### PR DESCRIPTION
Heavy1's install put the scratch/data dir under `%USERPROFILE%` on **C:** (446 GB, 98.6% full → 6.4 GB free), so with the 100 GB min-free guard the daemon could never download anything. The editors' machines must keep scratch on the big **D:** drive; the dedicated box must stay on **C:**.

- **v7.6.4** — the bootstrap detects the largest non-system fixed drive and puts the data dir (staging/output/db/logs) there. Code + venv stay small under the profile.
- **v7.6.5** — explicit `HD_DATA_DIR` env var to pin the data dir (e.g. `D:\HeavyDrops-data`) right from the worker one-liner, with certainty.
- **v7.6.6** — the largest-drive move only applies in **worker mode** (`HD_WORKER`). The dedicated box (HEAVY7) keeps its data on C: as before. Explicit `HD_DATA_DIR` wins in either case.

`bootstrap.ps1` verified ASCII-clean and brace-balanced. README + header document `HD_DATA_DIR`.

https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa)_