### PR TITLE
v7.6.7: writable default claims folder + fail-open on claims outage

### DIFF
--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.6.6"
+#define MyAppVersion "7.6.7"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/apply_worker_profile.py
+++ b/installer/apply_worker_profile.py
@@ -36,7 +36,9 @@ PROFILE = {
     },
     "coordination": {
         "enabled": True,
-        "claims_folder": "/_h265_claims",
+        # Inside the user's own folder so it's writable. The Dropbox namespace
+        # ROOT ("/_h265_claims") is NOT writable on a team/Business account.
+        "claims_folder": "/HeavyDrops/_h265_claims",
         "claim_ttl_minutes": 120,
         "heartbeat_minutes": 10,
     },

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.6.6 Installer
+# HeavyDrops Transcoder v7.6.7 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.6 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.7 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.6.6
+title HeavyDrops Transcoder v7.6.7
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.6.6
+echo   HeavyDrops Transcoder v7.6.7
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.6"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.7"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.6" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.6.7" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.6.6"
+$Shortcut.Description = "HeavyDrops Transcoder v7.6.7"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.6.6"
+version = "7.6.7"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.6.6"
+__version__ = "7.6.7"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/claims.py
+++ b/src/transcoder/claims.py
@@ -26,6 +26,7 @@ import hashlib
 import json
 import logging
 import threading
+import time
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Iterable
 
@@ -59,6 +60,7 @@ class ClaimStore:
         self.ttl = timedelta(minutes=ttl_minutes)
         self._held: set[str] = set()
         self._lock = threading.Lock()
+        self._last_warn = 0.0   # monotonic time of the last "unavailable" warning
 
     # ---- key / path / payload helpers --------------------------------------
 
@@ -86,34 +88,59 @@ class ClaimStore:
                 self._held.add(self._key(p))
 
     def try_claim(self, dropbox_path: str) -> bool:
-        """Attempt to claim a file. True → this machine may process it."""
+        """Attempt to claim a file. True → this machine may process it.
+
+        If the claims store itself is unreachable/misconfigured (e.g. the folder
+        isn't writable on a team Dropbox), we fail OPEN: warn once and let the
+        job proceed WITHOUT coordination, rather than jamming the whole pipeline
+        in a retry loop. Fix coordination.claims_folder to restore protection.
+        """
         key = self._key(dropbox_path)
         with self._lock:
             if key in self._held:
                 return True
 
         claim_path = self._claim_path(key)
-        if self.client.claim_create(claim_path, self._payload(dropbox_path)):
-            with self._lock:
-                self._held.add(key)
-            return True
+        try:
+            if self.client.claim_create(claim_path, self._payload(dropbox_path)):
+                with self._lock:
+                    self._held.add(key)
+                return True
 
-        # We lost the race — inspect the existing claim for staleness.
-        meta = self.client.get_metadata(claim_path)
-        if meta is None:
-            return False  # vanished underneath us; retry on the next pass
-        age = datetime.now(timezone.utc) - _as_utc(meta.server_modified)
-        if age <= self.ttl:
-            return False  # a live claim held by another machine
+            # We lost the race — inspect the existing claim for staleness.
+            meta = self.client.get_metadata(claim_path)
+            if meta is None:
+                return False  # vanished underneath us; retry on the next pass
+            age = datetime.now(timezone.utc) - _as_utc(meta.server_modified)
+            if age <= self.ttl:
+                return False  # a live claim held by another machine
 
-        # Abandoned claim → steal it.
-        self.client.delete_file(claim_path)
-        if self.client.claim_create(claim_path, self._payload(dropbox_path)):
-            with self._lock:
-                self._held.add(key)
-            logger.info("claims: stole abandoned claim (age %s) for %s", age, dropbox_path)
-            return True
-        return False
+            # Abandoned claim → steal it.
+            self.client.delete_file(claim_path)
+            if self.client.claim_create(claim_path, self._payload(dropbox_path)):
+                with self._lock:
+                    self._held.add(key)
+                logger.info("claims: stole abandoned claim (age %s) for %s", age, dropbox_path)
+                return True
+            return False
+        except Exception as e:
+            self._warn_unavailable(e)
+            return True  # fail open — don't block work on a claims outage/misconfig
+
+    def _warn_unavailable(self, err: Exception) -> None:
+        """Log a single rate-limited warning when the claims store is unusable."""
+        now = time.monotonic()
+        with self._lock:
+            if now - self._last_warn < 300:
+                return
+            self._last_warn = now
+        logger.warning(
+            "claims: cannot use claims folder '%s' (%s). Running WITHOUT "
+            "cross-machine coordination until fixed — point "
+            "coordination.claims_folder at a WRITABLE Dropbox path (on a team "
+            "account the namespace root is not writable; use a subfolder).",
+            self.folder, err,
+        )
 
     def heartbeat(self, dropbox_path: str) -> None:
         """Refresh the claim's timestamp so it isn't seen as abandoned."""

--- a/tests/test_claims.py
+++ b/tests/test_claims.py
@@ -119,6 +119,20 @@ def test_heartbeat_only_touches_held():
     assert fake.entries[cp]["server_modified"] > datetime.now(timezone.utc) - timedelta(minutes=1)
 
 
+def test_claim_failure_fails_open():
+    # A broken/unwritable claims store must not jam the pipeline: try_claim
+    # warns and returns True (proceed without coordination) instead of raising.
+    class BrokenDropbox(FakeDropbox):
+        def claim_create(self, path, content, encoding="utf-8"):
+            raise RuntimeError("no_write_permission")
+
+    fake = BrokenDropbox()
+    a = _store(fake, "Heavy1")
+    assert a.try_claim(PATH) is True
+    # The fail-open path does not record the key as held (we don't own a claim).
+    assert a._key(PATH) not in a.held_keys()
+
+
 def _fake_db(active_paths):
     jobs = [SimpleNamespace(dropbox_path=p) for p in active_paths]
     return SimpleNamespace(get_jobs_by_states=lambda states, limit=0: jobs)

--- a/tests/test_worker_profile.py
+++ b/tests/test_worker_profile.py
@@ -33,6 +33,7 @@ def test_profile_sets_expected_keys(tmp_path):
     assert data["availability"]["night_start"] == "18:00"
     assert data["availability"]["night_end"] == "09:00"
     assert data["coordination"]["enabled"] is True
+    assert data["coordination"]["claims_folder"] == "/HeavyDrops/_h265_claims"
     assert data["disk_budget"]["max_staging_bytes"] == 150_000_000_000
     assert data["concurrency"]["download_workers"] == 1
     assert data["concurrency"]["transcode_workers"] == 1

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.6.6
+HeavyDrops Transcoder v7.6.7
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.6.6"
+VERSION = "7.6.7"
 
 import socket
 import subprocess


### PR DESCRIPTION
On a team/Business Dropbox the namespace root isn't writable, so `claim_create` at `/_h265_claims` returned `no_write_permission` and the job looped forever with a full traceback (seen on Heavy1).

- Worker profile now defaults `coordination.claims_folder` to **`/HeavyDrops/_h265_claims`** (inside the user's own, writable folder) instead of the namespace root.
- `try_claim` now **fails open**: if the claims store is unreachable/misconfigured it logs a **single rate-limited warning** (no traceback) and lets the job proceed **without** coordination, instead of jamming the pipeline. Fixing `coordination.claims_folder` restores cross-machine protection.

Tests: fail-open returns True without recording a held claim; worker profile sets the writable folder. Full suite 90 passed, 1 pre-existing date time-bomb.

https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa)_