### PR TITLE
v7.7.0: night mode stops at dawn + yields to editor render apps (Media Encoder)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -117,6 +117,13 @@ availability:
   night_end: "07:00"
   pause_when_user_active: true
   idle_minutes: 10
+  # Pause while an editor's render app is running, so it doesn't fight for the
+  # GPU (e.g. an overnight Adobe Media Encoder queue). Empty list disables.
+  pause_when_apps:
+    - "Adobe Media Encoder"
+    - "Adobe Premiere Pro"
+    - "AfterFX"
+    - "Resolve"
   check_interval_sec: 60
 # Cross-machine claim: turn on when MORE THAN ONE machine shares the same
 # Dropbox folders, so exactly one machine processes each video. Off for a

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.6.7"
+#define MyAppVersion "7.7.0"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.6.7 Installer
+# HeavyDrops Transcoder v7.7.0 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.7 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.7.0 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.6.7
+title HeavyDrops Transcoder v7.7.0
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.6.7
+echo   HeavyDrops Transcoder v7.7.0
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.6.7"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.7.0"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.6.7" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.7.0" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.6.7"
+$Shortcut.Description = "HeavyDrops Transcoder v7.7.0"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.6.7"
+version = "7.7.0"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.6.7"
+__version__ = "7.7.0"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/availability.py
+++ b/src/transcoder/availability.py
@@ -14,6 +14,7 @@ dashboard (/api/pause) is never overridden.
 from __future__ import annotations
 
 import logging
+import subprocess
 import sys
 import threading
 from datetime import datetime, time as dtime
@@ -50,6 +51,31 @@ def user_idle_seconds() -> float | None:
         return None
 
 
+def running_process_names() -> set[str] | None:
+    """Lowercased set of running process image names (Windows). None if unknown.
+
+    Used to yield the GPU to an editor's render app (e.g. Adobe Media Encoder)
+    even when nobody is touching the keyboard — an overnight render queue looks
+    "idle" to GetLastInputInfo but is hammering the GPU.
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        out = subprocess.run(
+            ["tasklist", "/fo", "csv", "/nh"],
+            capture_output=True, text=True, timeout=20,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+        names: set[str] = set()
+        for line in out.stdout.splitlines():
+            line = line.strip()
+            if line.startswith('"'):
+                names.add(line.split('","', 1)[0].strip('"').lower())
+        return names or None
+    except Exception:  # pragma: no cover — never block on a detection failure
+        return None
+
+
 def parse_hhmm(value: str) -> dtime:
     """Parse 'HH:MM' into a time. Raises ValueError on a bad string."""
     hh, mm = value.strip().split(":")
@@ -73,7 +99,10 @@ class AvailabilityGate:
         self.config = config
 
     def should_work(
-        self, now: datetime, idle_seconds: float | None
+        self,
+        now: datetime,
+        idle_seconds: float | None,
+        running_procs: "set[str] | None" = None,
     ) -> tuple[bool, str]:
         a = self.config.availability
         if not a.enabled:
@@ -92,6 +121,15 @@ class AvailabilityGate:
         if a.pause_when_user_active and idle_seconds is not None:
             if idle_seconds < a.idle_minutes * 60:
                 return False, f"someone is using the machine ({idle_seconds:.0f}s idle)"
+
+        # Yield to an editor's render app (Adobe Media Encoder, Premiere, etc.)
+        # even if the keyboard is idle — their overnight render needs the GPU.
+        apps = [x for x in getattr(a, "pause_when_apps", []) or [] if x.strip()]
+        if apps and running_procs:
+            for app in apps:
+                al = app.lower()
+                if any(al in p for p in running_procs):
+                    return False, f"editor app running ({app})"
 
         return True, "inside night window, machine idle"
 
@@ -129,7 +167,7 @@ class AvailabilityWorker(threading.Thread):
         while not self.stop_event.is_set():
             try:
                 should, reason = self.gate.should_work(
-                    datetime.now(), user_idle_seconds()
+                    datetime.now(), user_idle_seconds(), running_process_names()
                 )
                 if should:
                     if self._paused_by_us and self.dispatcher.is_paused():

--- a/src/transcoder/config.py
+++ b/src/transcoder/config.py
@@ -513,6 +513,15 @@ class AvailabilitySettings(BaseModel):
         le=240,
         description="Minutes with no input before the machine counts as idle."
     )
+    pause_when_apps: list[str] = Field(
+        default_factory=lambda: [
+            "Adobe Media Encoder", "Adobe Premiere Pro", "AfterFX", "Resolve",
+        ],
+        description="Pause encoding while any of these apps is running (substring "
+                    "match on the Windows process name). So an editor's overnight "
+                    "Media Encoder render isn't slowed by the transcoder. Empty "
+                    "list disables this check."
+    )
     check_interval_sec: int = Field(
         default=60,
         ge=5,

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -51,6 +51,12 @@ class WorkerStop(Exception):
     pass
 
 
+class TranscodePaused(Exception):
+    """The transcode was interrupted because the pipeline paused (e.g. night
+    mode yielding the GPU). The job should be requeued, NOT retried/failed."""
+    pass
+
+
 class BaseWorker(threading.Thread):
     """Base class for pipeline workers."""
 
@@ -595,6 +601,15 @@ class TranscodeWorker(BaseWorker):
 
         try:
             self._transcode_job(job)
+        except TranscodePaused:
+            # Night mode (or a manual pause) interrupted this transcode. Put the
+            # job back so it's re-transcoded when work resumes — not a failure,
+            # so it doesn't burn a retry. The downloaded input stays on disk.
+            logger.info(
+                f"[{self.name}] Transcode paused — requeuing job {job.id} "
+                f"({Path(job.dropbox_path).name}) to finish later"
+            )
+            self.db.update_job_state(job.id, JobState.DOWNLOADED)
         except Exception as e:
             logger.error(f"[{self.name}] Transcode failed: {e}")
             self._handle_failure(job, str(e))
@@ -944,6 +959,12 @@ class TranscodeWorker(BaseWorker):
                     if self.should_stop():
                         self._kill_ffmpeg()
                         raise WorkerStop("Worker stopping")
+                    # If the pipeline was paused (night mode yielding the GPU,
+                    # or a manual dashboard pause), stop encoding NOW — don't
+                    # let the retry logic relaunch ffmpeg and keep the GPU busy.
+                    if self.dispatcher.is_paused():
+                        self._kill_ffmpeg()
+                        raise TranscodePaused()
                     try:
                         return_code = self._ffmpeg_process.wait(timeout=1.0)
                         break
@@ -954,6 +975,10 @@ class TranscodeWorker(BaseWorker):
                 tail_thread.join(timeout=3)
 
             if return_code != 0:
+                # If we're paused, the non-zero code is because the availability
+                # gate killed ffmpeg — treat it as a pause, not a real failure.
+                if self.dispatcher.is_paused():
+                    raise TranscodePaused()
                 # Surface the actual ffmpeg stderr so the operator can see
                 # why it bailed (codec init error, missing nvcuda.dll, bad
                 # input dimension for the HW encoder, etc). Code on its
@@ -968,7 +993,7 @@ class TranscodeWorker(BaseWorker):
 
             return True
 
-        except WorkerStop:
+        except (WorkerStop, TranscodePaused):
             raise
         except Exception as e:
             logger.error(f"[{self.name}] FFmpeg error: {e}")

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -13,6 +13,7 @@ def _gate(**kw):
     defaults = dict(
         enabled=True, night_start="20:00", night_end="07:00",
         pause_when_user_active=True, idle_minutes=10, check_interval_sec=60,
+        pause_when_apps=["Adobe Media Encoder", "Resolve"],
     )
     defaults.update(kw)
     return AvailabilityGate(SimpleNamespace(availability=SimpleNamespace(**defaults)))
@@ -81,3 +82,28 @@ def test_idle_check_off_ignores_activity():
 def test_invalid_window_fails_closed():
     ok, reason = _gate(night_start="banana").should_work(NIGHT, idle_seconds=None)
     assert not ok and "invalid" in reason
+
+
+def test_editor_app_running_blocks():
+    # Idle keyboard, inside window, but Media Encoder is rendering → yield.
+    procs = {"adobe media encoder.exe", "explorer.exe"}
+    ok, reason = _gate().should_work(NIGHT, idle_seconds=10_000, running_procs=procs)
+    assert not ok and "Adobe Media Encoder" in reason
+
+
+def test_no_editor_app_works():
+    procs = {"explorer.exe", "ffmpeg.exe"}
+    ok, _ = _gate().should_work(NIGHT, idle_seconds=10_000, running_procs=procs)
+    assert ok
+
+
+def test_app_check_skipped_when_procs_unknown():
+    # Non-Windows / detection failed → None → don't gate on apps.
+    ok, _ = _gate().should_work(NIGHT, idle_seconds=10_000, running_procs=None)
+    assert ok
+
+
+def test_empty_app_list_disables_check():
+    procs = {"adobe media encoder.exe"}
+    ok, _ = _gate(pause_when_apps=[]).should_work(NIGHT, idle_seconds=10_000, running_procs=procs)
+    assert ok

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.6.7
+HeavyDrops Transcoder v7.7.0
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.6.7"
+VERSION = "7.7.0"
 
 import socket
 import subprocess


### PR DESCRIPTION
Two night-mode fixes from a real overnight run on Heavy1 (it was still transcoding at 10:00).

**FIX — night mode now actually stops at dawn.** When the availability gate yielded (window closed or someone using the machine) it killed ffmpeg to free the GPU, but the transcode worker's "retry on ffmpeg failure" path treated the kill as a failure and **relaunched ffmpeg** — so it kept transcoding past 09:00. `_run_ffmpeg` now checks `dispatcher.is_paused()` and raises `TranscodePaused` instead of a retryable failure; the worker **requeues the job** (back to DOWNLOADED) to finish next window rather than retrying or failing it.

**FEATURE — yield to editor render apps.** `availability.pause_when_apps` (default Adobe Media Encoder / Premiere / AfterFX / Resolve) pauses the pipeline while one of those is running — an overnight Media Encoder render queue looks idle to `GetLastInputInfo` but hammers the GPU. Detected via `tasklist` on Windows; unknown elsewhere → not gated. `should_work` takes `running_procs` (pure/testable), the worker passes `running_process_names()`.

Covered by `tests/test_availability.py`. Full suite: 94 passed, 1 pre-existing date time-bomb.

https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa)_