### PR TITLE
v7.7.1: night mode also pauses in-flight downloads

### DIFF
--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.7.0"
+#define MyAppVersion "7.7.1"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.7.0 Installer
+# HeavyDrops Transcoder v7.7.1 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.7.0 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.7.1 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.7.0
+title HeavyDrops Transcoder v7.7.1
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.7.0
+echo   HeavyDrops Transcoder v7.7.1
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.7.0"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.7.1"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.7.0" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.7.1" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.7.0"
+$Shortcut.Description = "HeavyDrops Transcoder v7.7.1"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.7.0"
+version = "7.7.1"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.7.0"
+__version__ = "7.7.1"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -57,6 +57,12 @@ class TranscodePaused(Exception):
     pass
 
 
+class DownloadPaused(Exception):
+    """The download was interrupted because the pipeline paused (night mode).
+    The partial is kept and the job requeued, so it resumes next window."""
+    pass
+
+
 class BaseWorker(threading.Thread):
     """Base class for pipeline workers."""
 
@@ -223,6 +229,14 @@ class DownloadWorker(BaseWorker):
                 JobState.STABLE_WAIT,
                 error_message=str(e),
             )
+            if self.disk_budget is not None:
+                self.disk_budget.release(job.id)
+        except DownloadPaused:
+            logger.info(
+                f"[{self.name}] Download paused (night mode) — requeuing job "
+                f"{job.id}; resumes from the partial next window"
+            )
+            self.db.update_job_state(job.id, JobState.NEW)
             if self.disk_budget is not None:
                 self.disk_budget.release(job.id)
         except Exception as e:
@@ -491,6 +505,10 @@ class DownloadWorker(BaseWorker):
         def callback(downloaded: int, total: int) -> None:
             if self.should_stop():
                 raise WorkerStop("Worker stopping")
+            # Night mode (or a manual pause) — stop downloading too, not just
+            # transcoding. The partial is kept, so it resumes next window.
+            if self.dispatcher.is_paused():
+                raise DownloadPaused()
 
             REGISTRY.update(self.name, bytes_done=downloaded, bytes_total=total)
 

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.7.0
+HeavyDrops Transcoder v7.7.1
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.7.0"
+VERSION = "7.7.1"
 
 import socket
 import subprocess


### PR DESCRIPTION
Follow-up to v7.7.0. The user saw a **download running at 10:23** while the dispatcher showed PAUSED — night mode stopped the transcode but an in-flight download kept going to completion, still using the network and writing to the editors' D: drive past 09:00.

The download's progress callback now checks `dispatcher.is_paused()` and raises `DownloadPaused`; the worker keeps the partial and requeues the job (back to `NEW`), so it **resumes from where it left off** next window (downloads already support resume). With the window closed the machine is now genuinely idle — no GPU, no download.

Full suite: 94 passed, 1 pre-existing date time-bomb.

https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa)_