### PR TITLE
v7.7.2: bootstrap doesn't abort on a username with a space (Heavy 5/6)

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -165,7 +165,7 @@ if (-not (Test-Path $FFmpegExe) -or -not (Test-Path $FFprobeExe)) {
     Info "Downloading FFmpeg..."
     $zip = Join-Path $env:TEMP 'hd-ffmpeg.zip'
     $expand = Join-Path $env:TEMP 'hd-ffmpeg-unpack'
-    if (Test-Path $expand) { Remove-Item -Recurse -Force $expand }
+    if (Test-Path $expand) { Remove-Item -Recurse -Force $expand -ErrorAction SilentlyContinue }
     Invoke-WebRequest -Uri $FFmpegUrl -OutFile $zip -UseBasicParsing
     Expand-Archive -Path $zip -DestinationPath $expand -Force
 
@@ -176,8 +176,10 @@ if (-not (Test-Path $FFmpegExe) -or -not (Test-Path $FFprobeExe)) {
     }
     Copy-Item $srcFf.FullName $FFmpegExe  -Force
     Copy-Item $srcFp.FullName $FFprobeExe -Force
-    Remove-Item -Recurse -Force $expand
-    Remove-Item -Force $zip
+    # Temp cleanup is best-effort — never let it abort the install (e.g. a
+    # user folder with a space like "Heavy 5" trips Remove-Item's path parse).
+    Remove-Item -Recurse -Force $expand -ErrorAction SilentlyContinue
+    Remove-Item -Force $zip -ErrorAction SilentlyContinue
     Info "FFmpeg installed at $BinDir."
 }
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -176,7 +176,7 @@ if (-not (Test-Path $FFmpegExe) -or -not (Test-Path $FFprobeExe)) {
     }
     Copy-Item $srcFf.FullName $FFmpegExe  -Force
     Copy-Item $srcFp.FullName $FFprobeExe -Force
-    # Temp cleanup is best-effort — never let it abort the install (e.g. a
+    # Temp cleanup is best-effort - never let it abort the install (e.g. a
     # user folder with a space like "Heavy 5" trips Remove-Item's path parse).
     Remove-Item -Recurse -Force $expand -ErrorAction SilentlyContinue
     Remove-Item -Force $zip -ErrorAction SilentlyContinue

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.7.1"
+#define MyAppVersion "7.7.2"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.7.1 Installer
+# HeavyDrops Transcoder v7.7.2 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.7.1 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.7.2 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.7.1
+title HeavyDrops Transcoder v7.7.2
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.7.1
+echo   HeavyDrops Transcoder v7.7.2
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.7.1"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.7.2"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.7.1" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.7.2" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.7.1"
+$Shortcut.Description = "HeavyDrops Transcoder v7.7.2"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.7.1"
+version = "7.7.2"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.7.1"
+__version__ = "7.7.2"
 __author__ = "Dropbox Video Transcoder Team"

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.7.1
+HeavyDrops Transcoder v7.7.2
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.7.1"
+VERSION = "7.7.2"
 
 import socket
 import subprocess


### PR DESCRIPTION
Installing on Heavy5/Heavy6 (usernames "Heavy 5" / "Heavy 6", with a space) aborted right after "Downloading FFmpeg" with:

```
Remove-Item : An object at the specified path C:\Users\HEAVY5~1 does not exist.
At line:179 char:5 +     Remove-Item -Recurse -Force $expand
```

The FFmpeg temp cleanup (`Remove-Item` of the unpack dir / zip) trips on the space-in-username 8.3 path, and because the bootstrap runs under `$ErrorActionPreference='Stop'` it aborted the whole install — even though it was only deleting temp files. Cleanup is now best-effort (`-ErrorAction SilentlyContinue`) so it can never abort the install. (`bootstrap.ps1` kept strictly ASCII.)

The scheduled task already handles spaces: `<Command>`/`<WorkingDirectory>` take the whole path and `{CONFIG_PATH}` is quoted in `<Arguments>`.

https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa)_