### PR TITLE
v7.7.3: actually fix space-in-username install (try/catch around temp cleanup)

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -165,7 +165,7 @@ if (-not (Test-Path $FFmpegExe) -or -not (Test-Path $FFprobeExe)) {
     Info "Downloading FFmpeg..."
     $zip = Join-Path $env:TEMP 'hd-ffmpeg.zip'
     $expand = Join-Path $env:TEMP 'hd-ffmpeg-unpack'
-    if (Test-Path $expand) { Remove-Item -Recurse -Force $expand -ErrorAction SilentlyContinue }
+    if (Test-Path -LiteralPath $expand) { try { Remove-Item -LiteralPath $expand -Recurse -Force } catch {} }
     Invoke-WebRequest -Uri $FFmpegUrl -OutFile $zip -UseBasicParsing
     Expand-Archive -Path $zip -DestinationPath $expand -Force
 
@@ -176,10 +176,12 @@ if (-not (Test-Path $FFmpegExe) -or -not (Test-Path $FFprobeExe)) {
     }
     Copy-Item $srcFf.FullName $FFmpegExe  -Force
     Copy-Item $srcFp.FullName $FFprobeExe -Force
-    # Temp cleanup is best-effort - never let it abort the install (e.g. a
-    # user folder with a space like "Heavy 5" trips Remove-Item's path parse).
-    Remove-Item -Recurse -Force $expand -ErrorAction SilentlyContinue
-    Remove-Item -Force $zip -ErrorAction SilentlyContinue
+    # Temp cleanup is best-effort. A user folder with a space
+    # (C:\Users\Heavy 5 -> 8.3 HEAVY5~1) makes Remove-Item throw a TERMINATING
+    # ArgumentException that -ErrorAction can't swallow, so wrap in try/catch
+    # and use -LiteralPath. Never let temp cleanup abort the install.
+    try { Remove-Item -LiteralPath $expand -Recurse -Force } catch {}
+    try { Remove-Item -LiteralPath $zip -Force } catch {}
     Info "FFmpeg installed at $BinDir."
 }
 
@@ -266,7 +268,7 @@ $TaskXmlTmp = Join-Path $env:TEMP "hd-task-$PID.xml"
 
 Info "Registering scheduled task '$TaskName'..."
 schtasks /Create /TN $TaskName /XML $TaskXmlTmp /F | Out-Null
-Remove-Item -Force $TaskXmlTmp
+try { Remove-Item -LiteralPath $TaskXmlTmp -Force } catch {}
 
 Info "Starting daemon via Task Scheduler..."
 schtasks /Run /TN $TaskName | Out-Null

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.7.2"
+#define MyAppVersion "7.7.3"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.7.2 Installer
+# HeavyDrops Transcoder v7.7.3 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.7.2 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.7.3 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.7.2
+title HeavyDrops Transcoder v7.7.3
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.7.2
+echo   HeavyDrops Transcoder v7.7.3
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.7.2"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.7.3"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.7.2" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.7.3" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.7.2"
+$Shortcut.Description = "HeavyDrops Transcoder v7.7.3"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.7.2"
+version = "7.7.3"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.7.2"
+__version__ = "7.7.3"
 __author__ = "Dropbox Video Transcoder Team"

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.7.2
+HeavyDrops Transcoder v7.7.3
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.7.2"
+VERSION = "7.7.3"
 
 import socket
 import subprocess


### PR DESCRIPTION
v7.7.2 tried to fix the "Heavy 5"/"Heavy 6" install failure with `-ErrorAction SilentlyContinue` on the temp `Remove-Item`s — but it failed identically. The error is a **terminating `PSArgumentException`** raised during parameter binding (the 8.3 path `C:\Users\HEAVY5~1`), which `-ErrorAction` does **not** suppress.

Real fix: wrap all temp-file cleanups (ffmpeg unpack dir, ffmpeg zip, and the scheduled-task temp XML) in `try/catch` and use `-LiteralPath`. Temp cleanup can no longer abort the install. `bootstrap.ps1` kept ASCII-only.

https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBQTZgFw8gtMTpSfrNUpWa)_