### PR TITLE
v7.9.0: gate reorganize/delete on the Premiere project (.prproj), not "file touched" — plus the v7.8.0 404 + truncated-transcode + Proxies fixes

### DIFF
--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,55 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versão: 7.8.0
+Data: 10/06/2026
+--------------------------------------------------------------------------------
+
+Proxies nunca mais: pula tudo dentro de Proxies/ e pode apagar a pasta inteira
+
+  [FEATURE] Qualquer arquivo dentro de uma pasta Proxies/ agora é descartável
+            (antes só os com sufixo _Proxy estilo Sony — os proxies do
+            Premiere/DaVinci passavam batido e eram baixados e transcodados,
+            como os C8547_Proxy.mov da HEAVY7). O downloader também pula
+            jobs de proxy que já estavam na fila (enfileirados por scanner
+            antigo) — zero banda gasta.
+  [FEATURE] Com "delete throwaway" ligado, a pasta Proxies/ é apagada
+            INTEIRA num delete só (em vez de arquivo por arquivo, que
+            deixava a árvore vazia pra trás). Respeita a mesma trava de
+            idade do reorganize (legacy_reorganize_min_age_days): só apaga
+            pasta sem atividade há mais de N dias — edição ativa nunca é
+            tocada. Recuperável no histórico do Dropbox por ~30 dias.
+  [FEATURE] Novo toggle no dashboard (Settings): "Delete Premiere previews
+            + Proxies/ folders from Dropbox". Liga sem editar arquivo.
+
+Fim do loop infinito de download em arquivo que sumiu do Dropbox (404)
+
+  [FIX] Quando uma pasta era movida/renomeada/apagada no Dropbox depois do
+        scan, os jobs ficavam num loop eterno: 404 → retry com backoff →
+        FAILED → auto-revive ressuscitava → 404 de novo (HEAVY7: 22 jobs
+        girando pra sempre, log inundado). Agora o not_found é confirmado
+        com 1 consulta de metadata e o job vai pra SKIPPED_NOT_FOUND
+        (terminal — o auto-revive não toca). Se o arquivo voltar, o scanner
+        recria o job normalmente (rev nova).
+  [FIX] O retry interno do download_partial repetia o 404 com backoff
+        2+4+8+16s (8 chamadas inúteis por tentativa, no preflight HEVC).
+        Not-found agora curto-circuita na hora.
+
+Fim do loop infinito de transcode em arquivo com trecho corrompido
+
+  [FIX] Fonte com bitstream quebrado no meio fazia o decoder QSV/NVENC
+        desistir em silêncio: ffmpeg saía com código 0 mas o output parava
+        sempre no MESMO segundo (HEAVY7: 4178.7s → 2157.4s em TODA
+        tentativa, ~35 min de GPU por volta, pra sempre). Agora:
+          1. Truncou com decode de hardware → retenta UMA vez com decode
+             por software (decode sw + encoder de hardware igual), que
+             atravessa a região corrompida na maioria dos casos;
+          2. Truncou MESMO com decode de software → o fonte está quebrado
+             de verdade → SKIPPED_CORRUPT (terminal) + incidente automático
+             com o tail do ffmpeg.log.
+
+--------------------------------------------------------------------------------
+
 Versao: 7.6.3
 Data: 09/06/2026
 --------------------------------------------------------------------------------

--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,37 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versão: 7.9.0
+Data: 25/06/2026
+--------------------------------------------------------------------------------
+
+Reorganize e deleção agora seguem o PROJETO do Premiere, não "arquivo mexido"
+
+  [FIX] O conceito de "pasta ativa" estava errado. A trava de idade
+        (legacy_reorganize_min_age_days, padrão 60d) olhava se QUALQUER
+        arquivo da pasta tinha sido modificado nos últimos 60 dias — e usava
+        a data de UPLOAD do Dropbox (server_modified). Resultado: re-subir um
+        material velho (gravação de 2021) pro Dropbox "zerava o relógio", a
+        pasta parecia ativa e o daemon NUNCA fechava (h265 ficava no /h265,
+        h264 não era apagado) nem deletava Proxies. Era o que travava as
+        pastas recentes na HEAVY7 mesmo com material antigo.
+  [FEATURE] Agora o sinal é o projeto do Premiere (.prproj). O daemon sobe da
+            pasta da mídia até a pasta-de-entrega mais próxima que tenha um
+            .prproj e usa a data REAL de salvamento dele (client_modified):
+            projeto salvo há MENOS de 60 dias = em edição → segura; há mais de
+            60 dias → libera (fecha, troca o h265 no lugar, apaga o /h264 e a
+            pasta Proxies/). Se não existir .prproj em lugar nenhum (até o
+            dropbox_root), cai pra data REAL de gravação do próprio material.
+  [FIX] Passa a usar client_modified (a data real do arquivo em disco), nunca
+        server_modified (a hora em que o byte chegou no Dropbox). Re-sincronizar
+        um acervo antigo não congela mais o reorganize.
+  [NOTE] Vale para os DOIS caminhos com a mesma regra: o reorganize
+         (h264→h265 + deleção do backup /h264) E a deleção das pastas
+         Proxies/. Continua tudo recuperável no histórico do Dropbox (~30d) e
+         a pasta Proxies/ ainda é apagada INTEIRA num delete só.
+
+================================================================================
+
 Versão: 7.8.0
 Data: 10/06/2026
 --------------------------------------------------------------------------------

--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -14,14 +14,16 @@ Proxies nunca mais: pula tudo dentro de Proxies/ e pode apagar a pasta inteira
             como os C8547_Proxy.mov da HEAVY7). O downloader também pula
             jobs de proxy que já estavam na fila (enfileirados por scanner
             antigo) — zero banda gasta.
-  [FEATURE] Com "delete throwaway" ligado, a pasta Proxies/ é apagada
-            INTEIRA num delete só (em vez de arquivo por arquivo, que
-            deixava a árvore vazia pra trás). Respeita a mesma trava de
-            idade do reorganize (legacy_reorganize_min_age_days): só apaga
-            pasta sem atividade há mais de N dias — edição ativa nunca é
-            tocada. Recuperável no histórico do Dropbox por ~30 dias.
+  [FEATURE] A pasta Proxies/ é apagada INTEIRA num delete só (em vez de
+            arquivo por arquivo, que deixava a árvore vazia pra trás).
+            LIGADO POR PADRÃO, respeitando a mesma trava de idade do
+            reorganize (legacy_reorganize_min_age_days, padrão 60d): só
+            apaga pasta sem NENHUMA atividade há mais de N dias — edição
+            ativa nunca é tocada. Recuperável no histórico do Dropbox por
+            ~30 dias. Vale também pros previews do Premiere.
   [FEATURE] Novo toggle no dashboard (Settings): "Delete Premiere previews
-            + Proxies/ folders from Dropbox". Liga sem editar arquivo.
+            + Proxies/ folders from Dropbox" — serve pra DESLIGAR por
+            máquina se um dia precisar (sem editar arquivo).
 
 Fim do loop infinito de download em arquivo que sumiu do Dropbox (404)
 

--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,8 +2,24 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
-Versão: 7.9.0
+Versão: 8.0.0
 Data: 25/06/2026
+--------------------------------------------------------------------------------
+
+Proxies: pega tambem pasta "proxy" (singular) e arquivos *_Proxy.*
+
+  [FIX] O filtro de proxies so reconhecia pastas "Proxies/" (plural). Pastas
+        no singular "proxy/" (ex.: .../video/cam 03/proxy/C0462_Proxy.mov, que
+        apareciam no log da HEAVY7 baixando e dando retry) passavam batido e
+        eram baixadas/transcodadas. Agora "proxy" e "Proxies" (qualquer caixa)
+        contam igual.
+  [FEATURE] Volta a reconhecer o sufixo Sony *_Proxy.* (FX3 / A7S III) por
+            NOME de arquivo, pra pegar proxy largado FORA de uma pasta de
+            proxy (ao lado dos originais). Esses sao pulados/apagados arquivo
+            por arquivo; dentro de uma pasta proxy/Proxies continua sendo a
+            pasta inteira num delete so. Vale pro downloader (nao gasta banda)
+            e pro scanner (skip + delete opcional, com a mesma trava do .prproj).
+
 --------------------------------------------------------------------------------
 
 Reorganize e deleção agora seguem o PROJETO do Premiere, não "arquivo mexido"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -86,12 +86,13 @@ scanner:
   feito_cache_ttl_sec: 3600
   # Delete throwaway media from Dropbox during scan instead of just skipping:
   # Adobe Premiere preview caches (file-by-file) and entire Proxies/ folders
-  # (camera/NLE proxies — one delete for the whole folder). Gated by
-  # legacy_reorganize_min_age_days: a Proxies folder is only deleted once
-  # nothing inside it changed for that many days, so active edits are safe.
-  # Deletes are recoverable in Dropbox version history for ~30 days.
-  # Either way these files are NEVER downloaded/transcoded.
-  delete_throwaway_files: false
+  # (camera/NLE proxies — one delete for the whole folder). ON by default.
+  # Gated by legacy_reorganize_min_age_days (default 60): a Proxies folder is
+  # only deleted once nothing inside it was touched for that many days, so
+  # active edits are never affected. Deletes are recoverable in Dropbox
+  # version history for ~30 days. Either way these files are NEVER
+  # downloaded/transcoded. Set false to skip-but-keep.
+  delete_throwaway_files: true
 disk_budget:
   enabled: false
   max_staging_bytes: 2000000000000

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -84,6 +84,14 @@ dispatcher:
 scanner:
   cursor_checkpoint_entries: 500
   feito_cache_ttl_sec: 3600
+  # Delete throwaway media from Dropbox during scan instead of just skipping:
+  # Adobe Premiere preview caches (file-by-file) and entire Proxies/ folders
+  # (camera/NLE proxies — one delete for the whole folder). Gated by
+  # legacy_reorganize_min_age_days: a Proxies folder is only deleted once
+  # nothing inside it changed for that many days, so active edits are safe.
+  # Deletes are recoverable in Dropbox version history for ~30 days.
+  # Either way these files are NEVER downloaded/transcoded.
+  delete_throwaway_files: false
 disk_budget:
   enabled: false
   max_staging_bytes: 2000000000000

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.9.0"
+#define MyAppVersion "8.0.0"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.8.0"
+#define MyAppVersion "7.9.0"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "7.7.3"
+#define MyAppVersion "7.8.0"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.8.0 Installer
+# HeavyDrops Transcoder v7.9.0 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.8.0 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.9.0 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.8.0
+title HeavyDrops Transcoder v7.9.0
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.8.0
+echo   HeavyDrops Transcoder v7.9.0
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.8.0"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.9.0"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.8.0" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.9.0" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.8.0"
+$Shortcut.Description = "HeavyDrops Transcoder v7.9.0"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.9.0 Installer
+# HeavyDrops Transcoder v8.0.0 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.9.0 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v8.0.0 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.9.0
+title HeavyDrops Transcoder v8.0.0
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.9.0
+echo   HeavyDrops Transcoder v8.0.0
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.9.0"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v8.0.0"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.9.0" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v8.0.0" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.9.0"
+$Shortcut.Description = "HeavyDrops Transcoder v8.0.0"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v7.7.3 Installer
+# HeavyDrops Transcoder v7.8.0 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.7.3 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.8.0 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v7.7.3
+title HeavyDrops Transcoder v7.8.0
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v7.7.3
+echo   HeavyDrops Transcoder v7.8.0
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.7.3"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v7.8.0"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v7.7.3" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v7.8.0" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v7.7.3"
+$Shortcut.Description = "HeavyDrops Transcoder v7.8.0"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.8.0"
+version = "7.9.0"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.7.3"
+version = "7.8.0"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "7.9.0"
+version = "8.0.0"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.8.0"
+__version__ = "7.9.0"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.9.0"
+__version__ = "8.0.0"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/__init__.py
+++ b/src/transcoder/__init__.py
@@ -6,5 +6,5 @@ transcodes H.264 to H.265 (HEVC) using FFmpeg with hardware acceleration support
 and uploads the result back to Dropbox.
 """
 
-__version__ = "7.7.3"
+__version__ = "7.8.0"
 __author__ = "Dropbox Video Transcoder Team"

--- a/src/transcoder/api.py
+++ b/src/transcoder/api.py
@@ -1236,8 +1236,12 @@ def _reorganize_preview(api: ApiServer, body: dict) -> dict:
         by_parent.setdefault(cand.parent, {"video_pairs": [], "audio_pairs": []})["audio_pairs"] = cand.pairs
 
     rows = []
+    settled_cache: dict = {}
     for parent, slots in by_parent.items():
-        activity = is_folder_settled(dropbox, parent, threshold)
+        activity = is_folder_settled(
+            dropbox, parent, threshold,
+            dropbox_root=api.config.dropbox_root, cache=settled_cache,
+        )
         v_pairs = slots["video_pairs"]
         a_pairs = slots["audio_pairs"]
         total = len(v_pairs) + len(a_pairs)

--- a/src/transcoder/api.py
+++ b/src/transcoder/api.py
@@ -774,6 +774,11 @@ _SETTINGS_KNOBS: dict[str, dict] = {
         "yaml_key": "low_bitrate_skip_mbps_per_megapixel",
         "label": "Skip files with input bitrate below N Mbps per megapixel (0 = disable)",
     },
+    "delete_throwaway_files": {
+        "type": "bool",
+        "yaml_key": "scanner.delete_throwaway_files",
+        "label": "Delete throwaway media from Dropbox: Premiere previews + whole Proxies/ folders (waits for the reorganize age gate)",
+    },
     "cleanup_dot_underscore": {
         "type": "bool",
         "yaml_key": "cleanup_dot_underscore",
@@ -925,6 +930,7 @@ def _settings_payload(api: ApiServer) -> dict:
             "audio_workers": cfg.concurrency.audio_workers,
             "preserve_chroma_422": cfg.preserve_chroma_422,
             "low_bitrate_skip_mbps_per_megapixel": cfg.low_bitrate_skip_mbps_per_megapixel,
+            "delete_throwaway_files": cfg.scanner.delete_throwaway_files,
             "cleanup_dot_underscore": cfg.cleanup_dot_underscore,
             "cleanup_dot_underscore_delete_after_seconds": cfg.cleanup_dot_underscore_delete_after_seconds,
             "dropbox_root": cfg.dropbox_root,

--- a/src/transcoder/config.py
+++ b/src/transcoder/config.py
@@ -186,16 +186,17 @@ class ScannerSettings(BaseModel):
         description="Max age of a cached feito.txt read before it is refetched"
     )
     delete_throwaway_files: bool = Field(
-        default=False,
+        default=True,
         description=(
-            "When True, scanner DELETES throwaway media from Dropbox during "
-            "scan instead of just skipping it: Adobe Premiere preview-cache "
-            "files, and entire Proxies/ folders (camera/NLE proxies — the "
-            "whole folder goes in one delete). Both are gated by the "
-            "legacy_reorganize_min_age_days folder-age check, so a Proxies "
-            "folder is only deleted once it's older than that threshold. "
-            "Dropbox version history preserves the deletes for ~30 days. "
-            "Default False — opt-in because destructive."
+            "When True (default), scanner DELETES throwaway media from "
+            "Dropbox during scan instead of just skipping it: Adobe Premiere "
+            "preview-cache files, and entire Proxies/ folders (camera/NLE "
+            "proxies — the whole folder goes in one delete). Both are gated "
+            "by the legacy_reorganize_min_age_days folder-age check (default "
+            "60d), so a Proxies folder is only deleted once nothing inside "
+            "it was touched for that many days — active edits are never "
+            "affected. Dropbox version history preserves the deletes for "
+            "~30 days. Set False to skip-but-keep."
         ),
     )
 

--- a/src/transcoder/config.py
+++ b/src/transcoder/config.py
@@ -188,9 +188,12 @@ class ScannerSettings(BaseModel):
     delete_throwaway_files: bool = Field(
         default=False,
         description=(
-            "When True, scanner DELETES files it identifies as throwaway "
-            "(Adobe Premiere preview cache and Sony-style camera proxies) "
-            "from Dropbox during scan instead of just skipping them. "
+            "When True, scanner DELETES throwaway media from Dropbox during "
+            "scan instead of just skipping it: Adobe Premiere preview-cache "
+            "files, and entire Proxies/ folders (camera/NLE proxies — the "
+            "whole folder goes in one delete). Both are gated by the "
+            "legacy_reorganize_min_age_days folder-age check, so a Proxies "
+            "folder is only deleted once it's older than that threshold. "
             "Dropbox version history preserves the deletes for ~30 days. "
             "Default False — opt-in because destructive."
         ),

--- a/src/transcoder/dashboard.html
+++ b/src/transcoder/dashboard.html
@@ -666,6 +666,15 @@ async function renderSettings() {
       <span class="hint" style="color: #f59e0b;">⚠ Forces libx265 (CPU) for 4:2:2 sources. Encoding is roughly <b>10× slower</b> than QSV — a 4K 10-bit 4:2:2 clip of 1h becomes 5-10h of transcode. Only enable for masters that need chroma fidelity (graphics, chroma key). Default OFF.</span>
     </div>
     <div class="field">
+      <label>${lbl('delete_throwaway_files', 'Delete Premiere previews + Proxies/ folders from Dropbox')}</label>
+      <label class="switch">
+        <input id="set-del-throwaway" type="checkbox" ${s.delete_throwaway_files ? 'checked' : ''}>
+        <span class="track"></span>
+        <span style="color: var(--muted); font-size: .9em">${s.delete_throwaway_files ? 'ON — Proxies/ removed as a whole folder once settled' : 'OFF — proxies/previews are skipped but kept on Dropbox'}</span>
+      </label>
+      <span class="hint">Deletes only run after the folder is older than the reorganize wait above — active edits are never touched. Proxies/previews are never transcoded either way. Deletes are recoverable in Dropbox version history for ~30 days.</span>
+    </div>
+    <div class="field">
       <label>${lbl('cleanup_dot_underscore', "Quarantine ._ macOS metadata into 'ponto tracinho/'")}</label>
       <label class="switch">
         <input id="set-cleanup-dotu" type="checkbox" ${s.cleanup_dot_underscore ? 'checked' : ''}>
@@ -830,6 +839,7 @@ async function saveSettings() {
     legacy_reorganize_delete_wav_after_seconds: parseInt(document.getElementById('set-wav-del').value),
     audio_enabled: document.getElementById('set-audio-enabled').checked,
     audio_workers: parseInt(document.getElementById('set-audio-workers').value),
+    delete_throwaway_files: document.getElementById('set-del-throwaway').checked,
     cleanup_dot_underscore: document.getElementById('set-cleanup-dotu').checked,
     cleanup_dot_underscore_delete_after_seconds: parseInt(document.getElementById('set-cleanup-dotu-del').value),
     health_check_interval_minutes: parseInt(document.getElementById('set-health').value),

--- a/src/transcoder/dashboard.html
+++ b/src/transcoder/dashboard.html
@@ -672,7 +672,7 @@ async function renderSettings() {
         <span class="track"></span>
         <span style="color: var(--muted); font-size: .9em">${s.delete_throwaway_files ? 'ON — Proxies/ removed as a whole folder once settled' : 'OFF — proxies/previews are skipped but kept on Dropbox'}</span>
       </label>
-      <span class="hint">Deletes only run after the folder is older than the reorganize wait above — active edits are never touched. Proxies/previews are never transcoded either way. Deletes are recoverable in Dropbox version history for ~30 days.</span>
+      <span class="hint">ON by default. Deletes only run after the folder is older than the reorganize wait above — active edits are never touched. Proxies/previews are never transcoded either way. Deletes are recoverable in Dropbox version history for ~30 days.</span>
     </div>
     <div class="field">
       <label>${lbl('cleanup_dot_underscore', "Quarantine ._ macOS metadata into 'ponto tracinho/'")}</label>

--- a/src/transcoder/database.py
+++ b/src/transcoder/database.py
@@ -32,6 +32,7 @@ class JobState(str, Enum):
     SKIPPED_LOW_BITRATE = "SKIPPED_LOW_BITRATE"
     SKIPPED_EXCLUDED = "SKIPPED_EXCLUDED"
     SKIPPED_CORRUPT = "SKIPPED_CORRUPT"
+    SKIPPED_NOT_FOUND = "SKIPPED_NOT_FOUND"
     FAILED = "FAILED"
     RETRY_WAIT = "RETRY_WAIT"
 
@@ -54,6 +55,7 @@ TERMINAL_STATES = {
     JobState.SKIPPED_LOW_BITRATE,
     JobState.SKIPPED_EXCLUDED,
     JobState.SKIPPED_CORRUPT,
+    JobState.SKIPPED_NOT_FOUND,
 }
 
 # States that can be retried
@@ -218,7 +220,7 @@ CREATE INDEX IF NOT EXISTS idx_jobs_state_created ON jobs(state, created_at);
 -- when the same file is rediscovered between scans.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_active_path
     ON jobs(dropbox_path)
-    WHERE state NOT IN ('DONE','FAILED','SKIPPED_HEVC','SKIPPED_ALREADY_EXISTS','SKIPPED_TOO_SMALL','SKIPPED_LOW_BITRATE','SKIPPED_EXCLUDED','SKIPPED_CORRUPT');
+    WHERE state NOT IN ('DONE','FAILED','SKIPPED_HEVC','SKIPPED_ALREADY_EXISTS','SKIPPED_TOO_SMALL','SKIPPED_LOW_BITRATE','SKIPPED_EXCLUDED','SKIPPED_CORRUPT','SKIPPED_NOT_FOUND');
 
 -- Stability checks table: tracks file stability over time (R2)
 CREATE TABLE IF NOT EXISTS stability_checks (
@@ -403,7 +405,7 @@ class Database:
             "WHERE state NOT IN "
             "('DONE','FAILED','SKIPPED_HEVC','SKIPPED_ALREADY_EXISTS',"
             "'SKIPPED_TOO_SMALL','SKIPPED_LOW_BITRATE','SKIPPED_EXCLUDED',"
-            "'SKIPPED_CORRUPT')"
+            "'SKIPPED_CORRUPT','SKIPPED_NOT_FOUND')"
         )
 
     @contextmanager

--- a/src/transcoder/dropbox_client.py
+++ b/src/transcoder/dropbox_client.py
@@ -363,6 +363,15 @@ class DropboxClient:
                         f"retrying in {delay:.1f}s: {e}"
                     )
                     time.sleep(delay)
+            except DropboxNotFoundError:
+                # Permanent: the path is gone. Some operations (e.g.
+                # download_partial) probe-and-convert the ApiError inside
+                # their own closure, so the not-found arrives here already
+                # wrapped — without this re-raise it would fall into the
+                # generic handler below and burn the full 2+4+8+16s backoff
+                # on a 404 that can never succeed (the HEAVY7 preflight
+                # retry storm).
+                raise
             except Exception as e:
                 last_error = e
                 if attempt < self.max_retries - 1:

--- a/src/transcoder/dropbox_client.py
+++ b/src/transcoder/dropbox_client.py
@@ -99,6 +99,12 @@ class DropboxFileInfo:
     rev: str
     server_modified: datetime
     content_hash: str | None = None
+    # The mtime the uploading client stamped — i.e. the file's REAL on-disk
+    # date (camera capture time, or when Premiere last saved a .prproj). The
+    # Dropbox desktop sync client preserves it. Distinct from server_modified,
+    # which is just when the bytes landed on Dropbox (an old archive re-synced
+    # today has a recent server_modified but its original client_modified).
+    client_modified: datetime | None = None
 
     @classmethod
     def from_metadata(cls, metadata: FileMetadata) -> DropboxFileInfo:
@@ -110,6 +116,7 @@ class DropboxFileInfo:
             rev=metadata.rev,
             server_modified=metadata.server_modified,
             content_hash=metadata.content_hash,
+            client_modified=getattr(metadata, "client_modified", None),
         )
 
 

--- a/src/transcoder/ffmpeg_builder.py
+++ b/src/transcoder/ffmpeg_builder.py
@@ -121,6 +121,7 @@ class FFmpegCommandBuilder:
         output_path: Path,
         video_info: VideoInfo,
         encoder: EncoderType,
+        force_sw_decode: bool = False,
     ) -> FFmpegCommand:
         """
         Build FFmpeg transcode command.
@@ -130,6 +131,11 @@ class FFmpegCommandBuilder:
             output_path: Path for output video.
             video_info: Probed video information.
             encoder: Encoder to use.
+            force_sw_decode: Skip the hardware decoder and software-decode the
+                input (hybrid mode) even when the HW decoder could handle it.
+                Used to recover sources whose bitstream makes the QSV/NVENC
+                decoder bail mid-file while ffmpeg still exits 0 — software
+                decode is far more error-tolerant. The encoder stays HW.
 
         Returns:
             FFmpegCommand ready for execution.
@@ -158,7 +164,7 @@ class FFmpegCommandBuilder:
         # ~5-10x faster than pure libx265 because the encode itself is
         # still hardware. Detected upfront so we don't waste two failed
         # ffmpeg launches before the auto-fallback kicks in.
-        args.extend(self._get_input_hwaccel(encoder, video_info))
+        args.extend(self._get_input_hwaccel(encoder, video_info, force_sw_decode))
 
         # Input file
         args.extend(["-i", str(input_path)])
@@ -212,7 +218,7 @@ class FFmpegCommandBuilder:
         # mode (sw decode for 4:2:2/4:4:4 inputs the HW decoder rejects).
         # No-op for libx265 (pix_fmt covers it) and no-op when full HW
         # decode is in play.
-        args.extend(self._get_video_filter_args(encoder, video_info))
+        args.extend(self._get_video_filter_args(encoder, video_info, force_sw_decode))
 
         # Video encoder settings
         args.extend(self._get_video_encoder_args(encoder, profile, video_info))
@@ -239,6 +245,8 @@ class FFmpegCommandBuilder:
             f"{video_info.width}x{video_info.height}, "
             f"{video_info.duration_sec:.1f}s"
         )
+        if force_sw_decode:
+            description += " (forced sw decode)"
 
         return FFmpegCommand(
             args=args,
@@ -275,8 +283,16 @@ class FFmpegCommandBuilder:
         self,
         encoder: EncoderType,
         video_info: VideoInfo | None = None,
+        force_sw_decode: bool = False,
     ) -> list[str]:
         """Get input hardware acceleration arguments."""
+        if force_sw_decode and encoder != EncoderType.CPU:
+            logger.info(
+                "ffmpeg: %s hardware decode disabled by caller (forced sw "
+                "decode); using software decode + %s hardware encode",
+                encoder.value, encoder.value,
+            )
+            return []
         if encoder == EncoderType.QSV:
             if self._hw_can_decode_input(video_info):
                 return ["-hwaccel", "qsv", "-hwaccel_output_format", "qsv"]
@@ -306,6 +322,7 @@ class FFmpegCommandBuilder:
         self,
         encoder: EncoderType,
         video_info: VideoInfo,
+        force_sw_decode: bool = False,
     ) -> list[str]:
         """Software chroma/format conversion filter, used when:
           - the hardware encoder needs 4:2:0 but the source is 4:2:2; AND
@@ -319,8 +336,10 @@ class FFmpegCommandBuilder:
         if encoder == EncoderType.CPU:
             return []
         # If hwaccel is active (frames live on GPU surfaces), no
-        # software filter is appropriate.
-        if self._hw_can_decode_input(video_info):
+        # software filter is appropriate. force_sw_decode means the caller
+        # disabled hwaccel, so the filter IS needed regardless of chroma —
+        # the sw-decoded frames must be formatted for the HW encoder.
+        if self._hw_can_decode_input(video_info) and not force_sw_decode:
             return []
         # Hybrid mode: pick the same pix_fmt the encoder will produce so
         # the chroma reduction happens once, in software, before upload.
@@ -551,13 +570,17 @@ class FFmpegCommandBuilder:
         output_path: Path,
         video_info: VideoInfo,
         encoder: EncoderType,
+        force_sw_decode: bool = False,
     ) -> FFmpegCommand:
         """
         Build command with audio re-encoding fallback.
 
         Used when audio copy fails (incompatible codec).
         """
-        cmd = self.build_transcode_command(input_path, output_path, video_info, encoder)
+        cmd = self.build_transcode_command(
+            input_path, output_path, video_info, encoder,
+            force_sw_decode=force_sw_decode,
+        )
 
         # Replace audio copy with re-encode
         new_args = []

--- a/src/transcoder/main.py
+++ b/src/transcoder/main.py
@@ -1329,9 +1329,13 @@ def reorganize_existing(
 
     ready: list = []
     deferred: list = []
+    settled_cache: dict = {}
 
     for cand in candidates:
-        activity = is_folder_settled(dropbox, cand.parent, threshold)
+        activity = is_folder_settled(
+            dropbox, cand.parent, threshold,
+            dropbox_root=root, cache=settled_cache,
+        )
         cand.activity = activity
         if not activity.settled:
             cand.skip_reason = (

--- a/src/transcoder/reorganize.py
+++ b/src/transcoder/reorganize.py
@@ -31,44 +31,165 @@ class FolderActivity:
     newest_modified: datetime | None
     days_since_newest: float | None
     threshold_days: int
+    # Which signal decided this: "prproj" (an Adobe Premiere project drove it),
+    # "media" (no project found — fell back to the footage's real date),
+    # "empty" (nothing to protect), or "disabled" (min_age_days <= 0).
+    source: str = "media"
+
+
+# Extensions whose mtime means "an edit is in progress here". A Premiere
+# project's last-save time is the truth about whether a folder of footage is
+# still being worked on — far better than "was any file in the folder touched",
+# which a bulk re-upload of finished, years-old footage trips falsely.
+_EDIT_PROJECT_EXTS = (".prproj",)
+
+# Daemon-written files that are never "user activity".
+_NON_ACTIVITY_NAMES = {"h265 feito.txt", "mp3 feito.txt"}
+
+# How many ancestor levels to walk up looking for the nearest .prproj before
+# giving up and using the media-date fallback. Bounds Dropbox calls on a
+# pathological tree; real edit folders sit a few levels above the media.
+_PROJECT_SEARCH_MAX_DEPTH = 10
+
+
+def _to_naive_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _is_project_file(name: str) -> bool:
+    low = name.lower()
+    return any(low.endswith(ext) for ext in _EDIT_PROJECT_EXTS)
+
+
+def _real_modified(entry: DropboxFileInfo) -> datetime | None:
+    """The file's real on-disk date (client_modified), falling back to the
+    Dropbox upload time only if the client date is missing."""
+    return _to_naive_utc(entry.client_modified or entry.server_modified)
+
+
+def _newest_prproj_modified(
+    dropbox: DropboxClient,
+    folder: str,
+    cache: dict | None = None,
+) -> datetime | None:
+    """Newest .prproj real save-time directly in `folder`, or None if none."""
+    if cache is not None and folder in cache:
+        return cache[folder]
+    newest: datetime | None = None
+    try:
+        for entry in dropbox.list_folder(folder, recursive=False):
+            if not _is_project_file(entry.name):
+                continue
+            modified = _real_modified(entry)
+            if modified is not None and (newest is None or modified > newest):
+                newest = modified
+    except DropboxNotFoundError:
+        newest = None
+    if cache is not None:
+        cache[folder] = newest
+    return newest
+
+
+def _ancestor_chain(start: str, dropbox_root: str | None, max_depth: int) -> list[str]:
+    """`start` then each parent, up to and including dropbox_root (or '/'),
+    never above it, capped at max_depth."""
+    ceiling = PurePosixPath("/" + dropbox_root.strip("/")) if dropbox_root else PurePosixPath("/")
+
+    def under(x: PurePosixPath) -> bool:
+        return x == ceiling or ceiling in x.parents
+
+    chain: list[str] = []
+    p = PurePosixPath(start)
+    for anc in [p, *p.parents]:
+        if not under(anc):
+            break
+        chain.append(str(anc))
+        if anc == ceiling or len(chain) >= max_depth:
+            break
+    return chain
 
 
 def is_folder_settled(
     dropbox: DropboxClient,
     parent: str,
     min_age_days: int,
+    *,
+    dropbox_root: str | None = None,
+    cache: dict | None = None,
 ) -> FolderActivity:
     """
-    Check whether `parent` has had user activity in the last `min_age_days`.
+    Decide whether `parent` belongs to an edit that is DONE — so its H.265
+    outputs may be swapped in and the H.264 backups deleted.
 
-    "Activity" = any file directly in `parent` (non-recursive — files in
-    /h264 and /h265 subfolders don't count, since those are the daemon's
-    own outputs/backups). Returns settled=True when the newest such file is
-    older than the threshold (or when the folder has no files at all).
+    The signal is the Adobe Premiere project (.prproj), NOT "was any file in
+    the folder touched recently":
+
+      1. Walk up from `parent` to the nearest ancestor holding a .prproj and
+         use that project's real last-save time (client_modified). A project
+         saved within `min_age_days` is still being edited -> NOT settled.
+      2. If no .prproj exists anywhere up to `dropbox_root`, fall back to the
+         real capture date (client_modified) of the media directly in `parent`.
+
+    Crucially this uses client_modified (the real on-disk date), never
+    server_modified (the Dropbox upload time): a folder of years-old footage
+    that was merely re-synced to Dropbox last week must still read as settled,
+    and re-syncing must never reset the clock and freeze reorganization.
+
+    `cache` (caller-owned, scoped to a single pass) memoises per-folder .prproj
+    lookups so sibling media folders sharing an ancestor don't re-list it.
 
     A min_age_days of 0 short-circuits to settled=True.
     """
     if min_age_days <= 0:
-        return FolderActivity(True, None, None, min_age_days)
+        return FolderActivity(True, None, None, min_age_days, source="disabled")
 
-    threshold = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=min_age_days)
-    newest: datetime | None = None
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    threshold = now - timedelta(days=min_age_days)
 
+    # One pass over `parent`: capture both its own .prproj (if any) and the
+    # newest real media date, so the no-project path never lists it twice.
+    parent_prproj: datetime | None = None
+    media_newest: datetime | None = None
     for entry in dropbox.list_folder(parent, recursive=False):
-        if entry.name.lower() == "h265 feito.txt":
-            # Daemon-written journal, not user activity.
+        modified = _real_modified(entry)
+        if modified is None:
             continue
-        modified = entry.server_modified
-        if modified.tzinfo is not None:
-            modified = modified.astimezone(timezone.utc).replace(tzinfo=None)
-        if newest is None or modified > newest:
-            newest = modified
+        if _is_project_file(entry.name):
+            if parent_prproj is None or modified > parent_prproj:
+                parent_prproj = modified
+            continue
+        if entry.name.lower() in _NON_ACTIVITY_NAMES:
+            continue
+        if media_newest is None or modified > media_newest:
+            media_newest = modified
+    if cache is not None:
+        cache[parent] = parent_prproj
 
-    if newest is None:
-        return FolderActivity(True, None, None, min_age_days)
+    prproj = parent_prproj
+    if prproj is None:
+        # Nearest .prproj strictly above `parent`, up to dropbox_root.
+        ancestors = _ancestor_chain(
+            str(PurePosixPath(parent).parent), dropbox_root, _PROJECT_SEARCH_MAX_DEPTH,
+        )
+        for folder in ancestors:
+            found = _newest_prproj_modified(dropbox, folder, cache)
+            if found is not None:
+                prproj = found
+                break
 
-    days_since = (datetime.now(timezone.utc).replace(tzinfo=None) - newest).total_seconds() / 86400.0
-    return FolderActivity(newest < threshold, newest, days_since, min_age_days)
+    if prproj is not None:
+        days = (now - prproj).total_seconds() / 86400.0
+        return FolderActivity(prproj < threshold, prproj, days, min_age_days, source="prproj")
+
+    # No project anywhere — fall back to the footage's real date.
+    if media_newest is None:
+        return FolderActivity(True, None, None, min_age_days, source="empty")
+    days_since = (now - media_newest).total_seconds() / 86400.0
+    return FolderActivity(media_newest < threshold, media_newest, days_since, min_age_days, source="media")
 
 
 @dataclass

--- a/src/transcoder/scanner.py
+++ b/src/transcoder/scanner.py
@@ -330,10 +330,14 @@ class Scanner:
         # days"). The skip itself is always safe and runs regardless of
         # folder age.
         is_preview = _path_is_premiere_preview(path)
-        is_proxy = _path_is_in_proxies_folder(path)
+        is_proxy_folder = _path_is_in_proxies_folder(path)
+        is_proxy_file = _path_is_proxy_filename(path)
+        is_proxy = is_proxy_folder or is_proxy_file
         if is_preview or is_proxy:
             kind = "Premiere preview" if is_preview else "camera/NLE proxy"
-            proxy_root = _proxies_folder_root(path) if is_proxy else None
+            # Whole-folder delete only when inside a proxy folder; a loose
+            # _Proxy.* file (or a preview) is handled file-by-file.
+            proxy_root = _proxies_folder_root(path) if is_proxy_folder else None
             if proxy_root is not None and proxy_root in self._deleted_proxy_dirs:
                 logger.debug(
                     f"Skipping (throwaway {kind}, Proxies folder already "
@@ -741,5 +745,6 @@ def _cursor_preview(cursor: str | None) -> str:
 from .utils import path_has_assets_segment as _path_has_assets_segment  # noqa: E402
 from .utils import path_is_premiere_preview as _path_is_premiere_preview  # noqa: E402
 from .utils import path_is_in_proxies_folder as _path_is_in_proxies_folder  # noqa: E402
+from .utils import path_is_proxy_filename as _path_is_proxy_filename  # noqa: E402
 from .utils import proxies_folder_root as _proxies_folder_root  # noqa: E402
 from .reorganize import is_folder_settled as _is_folder_settled  # noqa: E402

--- a/src/transcoder/scanner.py
+++ b/src/transcoder/scanner.py
@@ -71,6 +71,11 @@ class Scanner:
         # In-process memoisation of feito.txt reads within a single scan call,
         # backed by a persistent DB cache across scans.
         self._feito_memo: dict[str, set[str]] = {}
+        # Proxies/ folders already deleted (or confirmed gone) — every file
+        # inside a deleted folder still shows up as its own scan entry, so
+        # without this memo each sibling would re-issue the settled check +
+        # delete call against a folder that no longer exists.
+        self._deleted_proxy_dirs: set[str] = set()
 
     # ------------------------------------------------------------------ public
 
@@ -82,6 +87,9 @@ class Scanner:
         """
         stats = self._empty_stats()
         self._feito_memo.clear()
+        # Per-scan memo: a Proxies/ folder recreated by a new edit session
+        # must be re-evaluated on later scans once it ages past the gate.
+        self._deleted_proxy_dirs.clear()
 
         state = self.db.get_scan_state(self.config.dropbox_root)
         logger.info(
@@ -298,33 +306,49 @@ class Scanner:
             logger.debug(f"Skipping (under /assets/): {path}")
             return 'skipped_excluded'
 
-        # Throwaway files: Adobe Premiere preview cache and Sony-style
-        # camera proxies. Both are regenerable/redundant — transcoding
-        # them wastes bandwidth + CPU. Always skip; optionally delete
-        # from Dropbox when scanner.delete_throwaway_files is on
-        # (Dropbox version history covers the delete for ~30 days).
+        # Throwaway files: Adobe Premiere preview cache and camera/NLE
+        # proxies (anything under a `Proxies/` folder). Both are
+        # regenerable/redundant — transcoding them wastes bandwidth + CPU.
+        # Always skip; optionally delete from Dropbox when
+        # scanner.delete_throwaway_files is on (Dropbox version history
+        # covers the delete for ~30 days). Proxies are deleted as a WHOLE
+        # FOLDER (one files_delete_v2 on the Proxies/ root) — per-file
+        # deletes left empty Proxies trees behind and missed files that
+        # don't follow the Sony `*_Proxy.*` naming.
         #
         # SAFETY: when deleting, gate behind the same folder-age check
         # that reorganize uses (is_folder_settled / legacy_reorganize_min_age_days).
         # If the editor was active in the folder recently, deleting the
         # Premiere previews would interrupt an in-flight render and force
         # Premiere to regenerate them — disruptive. Same for proxies during
-        # an active offline edit. The skip itself is always safe and runs
-        # regardless of folder age.
+        # an active offline edit ("delete Proxies folders older than X
+        # days"). The skip itself is always safe and runs regardless of
+        # folder age.
         is_preview = _path_is_premiere_preview(path)
-        is_proxy = _path_is_camera_proxy(path)
+        is_proxy = _path_is_in_proxies_folder(path)
         if is_preview or is_proxy:
-            kind = "Premiere preview" if is_preview else "camera proxy"
+            kind = "Premiere preview" if is_preview else "camera/NLE proxy"
+            proxy_root = _proxies_folder_root(path) if is_proxy else None
+            if proxy_root is not None and proxy_root in self._deleted_proxy_dirs:
+                logger.debug(
+                    f"Skipping (throwaway {kind}, Proxies folder already "
+                    f"deleted this scan): {path}"
+                )
+                return 'skipped_excluded'
             if (
                 getattr(self.config.scanner, "delete_throwaway_files", False)
                 and not dry_run
             ):
-                parent = str(PurePosixPath(path).parent)
+                # For proxies, both the age check and the delete target the
+                # Proxies/ folder itself — its newest entry is exactly "how
+                # old the proxies are". Previews stay file-by-file.
+                target = proxy_root or path
+                age_scope = proxy_root or str(PurePosixPath(path).parent)
                 min_age = int(getattr(
                     self.config, "legacy_reorganize_min_age_days", 0
                 ) or 0)
                 try:
-                    settled = _is_folder_settled(self.dropbox, parent, min_age)
+                    settled = _is_folder_settled(self.dropbox, age_scope, min_age)
                 except Exception as e:
                     logger.warning(
                         f"Skipping (throwaway {kind}, folder-age check failed): "
@@ -346,20 +370,22 @@ class Scanner:
                     return 'skipped_excluded'
 
                 try:
-                    deleted = self.dropbox.delete_file(path)
+                    deleted = self.dropbox.delete_file(target)
                 except Exception as e:
                     logger.warning(
-                        f"Skipping (throwaway {kind}, delete failed): {path}: {e}"
+                        f"Skipping (throwaway {kind}, delete failed): {target}: {e}"
                     )
                 else:
+                    if proxy_root is not None:
+                        self._deleted_proxy_dirs.add(proxy_root)
                     if deleted:
                         logger.info(
-                            f"Deleted throwaway {kind} from Dropbox: {path} "
+                            f"Deleted throwaway {kind} from Dropbox: {target} "
                             f"(recoverable via version history for ~30 days)"
                         )
                     else:
                         logger.debug(
-                            f"Throwaway {kind} already gone from Dropbox: {path}"
+                            f"Throwaway {kind} already gone from Dropbox: {target}"
                         )
             else:
                 logger.debug(f"Skipping (throwaway {kind}): {path}")
@@ -705,5 +731,6 @@ def _cursor_preview(cursor: str | None) -> str:
 # scanner keep working without churn.
 from .utils import path_has_assets_segment as _path_has_assets_segment  # noqa: E402
 from .utils import path_is_premiere_preview as _path_is_premiere_preview  # noqa: E402
-from .utils import path_is_camera_proxy as _path_is_camera_proxy  # noqa: E402
+from .utils import path_is_in_proxies_folder as _path_is_in_proxies_folder  # noqa: E402
+from .utils import proxies_folder_root as _proxies_folder_root  # noqa: E402
 from .reorganize import is_folder_settled as _is_folder_settled  # noqa: E402

--- a/src/transcoder/scanner.py
+++ b/src/transcoder/scanner.py
@@ -76,6 +76,10 @@ class Scanner:
         # without this memo each sibling would re-issue the settled check +
         # delete call against a folder that no longer exists.
         self._deleted_proxy_dirs: set[str] = set()
+        # Per-scan memo of .prproj lookups (folder -> newest project mtime or
+        # None) so sibling media folders sharing an edit ancestor don't each
+        # re-list the whole chain during the settled check.
+        self._settled_prproj_cache: dict = {}
 
     # ------------------------------------------------------------------ public
 
@@ -90,6 +94,7 @@ class Scanner:
         # Per-scan memo: a Proxies/ folder recreated by a new edit session
         # must be re-evaluated on later scans once it ages past the gate.
         self._deleted_proxy_dirs.clear()
+        self._settled_prproj_cache.clear()
 
         state = self.db.get_scan_state(self.config.dropbox_root)
         logger.info(
@@ -348,7 +353,11 @@ class Scanner:
                     self.config, "legacy_reorganize_min_age_days", 0
                 ) or 0)
                 try:
-                    settled = _is_folder_settled(self.dropbox, age_scope, min_age)
+                    settled = _is_folder_settled(
+                        self.dropbox, age_scope, min_age,
+                        dropbox_root=getattr(self.config, "dropbox_root", None),
+                        cache=self._settled_prproj_cache,
+                    )
                 except Exception as e:
                     logger.warning(
                         f"Skipping (throwaway {kind}, folder-age check failed): "

--- a/src/transcoder/utils.py
+++ b/src/transcoder/utils.py
@@ -187,39 +187,58 @@ def path_is_premiere_preview(path: str) -> bool:
 # Sony-named `*_Proxy.*` files were matched; the operator confirmed every
 # `Proxies/` folder in this pipeline is regenerable, so the whole folder
 # is now treated as throwaway regardless of the file naming inside.
-_PROXIES_SEGMENT_NAME = "proxies"
+# Folder names cameras/NLEs use for the proxy tree. Sony/Premiere/DaVinci
+# write `Proxies/`; some camera dumps use a singular `proxy/` next to the
+# originals (e.g. `cam 03/proxy/C0462_Proxy.mov`). Both are throwaway.
+_PROXIES_SEGMENT_NAMES = {"proxies", "proxy"}
 
 
 def path_is_in_proxies_folder(path: str) -> bool:
-    """True when the path lives anywhere under a `Proxies/` folder.
+    """True when the path lives anywhere under a proxy folder (`Proxies/` or
+    `proxy/`).
 
-    Case-insensitive segment match, any depth — Premiere proxy trees
-    nest as `Proxies/<resolution>/clip.mov`, Sony as `Proxies/clip_Proxy.mp4`.
+    Case-insensitive segment match, any depth — Premiere proxy trees nest as
+    `Proxies/<resolution>/clip.mov`, Sony as `Proxies/clip_Proxy.mp4`, and some
+    camera setups use a singular `proxy/` beside the originals.
     """
     if not path:
         return False
     from pathlib import PurePosixPath
     return any(
-        seg.lower() == _PROXIES_SEGMENT_NAME
+        seg.lower() in _PROXIES_SEGMENT_NAMES
         for seg in PurePosixPath(path).parts
     )
 
 
 def proxies_folder_root(path: str) -> str | None:
-    """Return the path of the outermost `Proxies/` ancestor of `path`.
+    """Return the path of the outermost proxy-folder ancestor of `path`.
 
-    `/a/b/Proxies/sub/clip.mov` → `/a/b/Proxies`. None when the path has
-    no Proxies segment. Used to delete the whole proxy tree in one
-    files_delete_v2 call instead of file-by-file.
+    `/a/b/Proxies/sub/clip.mov` → `/a/b/Proxies`; `/a/cam 03/proxy/x.mov` →
+    `/a/cam 03/proxy`. None when the path has no proxy segment. Used to delete
+    the whole proxy tree in one files_delete_v2 call instead of file-by-file.
     """
     if not path:
         return None
     from pathlib import PurePosixPath
     parts = PurePosixPath(path).parts
     for i, seg in enumerate(parts):
-        if seg.lower() == _PROXIES_SEGMENT_NAME:
+        if seg.lower() in _PROXIES_SEGMENT_NAMES:
             return str(PurePosixPath(*parts[: i + 1]))
     return None
+
+
+def path_is_proxy_filename(path: str) -> bool:
+    """True when the filename is a Sony-style proxy: stem ends with `_proxy`
+    (case-insensitive), e.g. `C0462_Proxy.mov`.
+
+    Catches proxies dropped NEXT to the originals rather than inside a proxy
+    folder. These are skipped file-by-file (there's no proxy folder to delete
+    wholesale). `approxy.mov` is NOT matched (needs the `_` separator).
+    """
+    if not path:
+        return False
+    from pathlib import PurePosixPath
+    return PurePosixPath(path).stem.lower().endswith("_proxy")
 
 
 # Codecs that ffprobe reports for files that are technically images

--- a/src/transcoder/utils.py
+++ b/src/transcoder/utils.py
@@ -179,29 +179,47 @@ def path_is_premiere_preview(path: str) -> bool:
     return False
 
 
-# Sony cameras (FX3, A7S III, etc.) write low-bitrate proxy copies of every
-# clip into a `Proxies/` subfolder, named `<original>_Proxy.<ext>`. They're
-# only useful for offline edit on slower machines — if the user has the
-# originals (we already scan those), transcoding the proxies is pure waste.
-_PROXIES_SEGMENT_NAMES = {"Proxies", "proxies", "PROXIES"}
+# Cameras (Sony FX3/A7S III: `<original>_Proxy.<ext>`) and NLEs (Premiere
+# "Create proxies", DaVinci) write low-bitrate proxy copies of every clip
+# into a `Proxies/` subfolder. They're only useful for offline edit on
+# slower machines — if the user has the originals (we already scan those),
+# downloading/transcoding the proxies is pure waste. Until v7.7.x only
+# Sony-named `*_Proxy.*` files were matched; the operator confirmed every
+# `Proxies/` folder in this pipeline is regenerable, so the whole folder
+# is now treated as throwaway regardless of the file naming inside.
+_PROXIES_SEGMENT_NAME = "proxies"
 
 
-def path_is_camera_proxy(path: str) -> bool:
-    """True when the path is a Sony-style camera proxy file.
+def path_is_in_proxies_folder(path: str) -> bool:
+    """True when the path lives anywhere under a `Proxies/` folder.
 
-    Pattern: any path segment named `Proxies/` AND the file basename ends
-    with `_Proxy.<ext>` (Sony convention). The basename check is the
-    safety net so unrelated files in a folder coincidentally called
-    "Proxies/" don't get nuked.
+    Case-insensitive segment match, any depth — Premiere proxy trees
+    nest as `Proxies/<resolution>/clip.mov`, Sony as `Proxies/clip_Proxy.mp4`.
     """
     if not path:
         return False
     from pathlib import PurePosixPath
-    p = PurePosixPath(path)
-    if not any(seg in _PROXIES_SEGMENT_NAMES for seg in p.parts):
-        return False
-    stem = p.stem
-    return stem.lower().endswith("_proxy")
+    return any(
+        seg.lower() == _PROXIES_SEGMENT_NAME
+        for seg in PurePosixPath(path).parts
+    )
+
+
+def proxies_folder_root(path: str) -> str | None:
+    """Return the path of the outermost `Proxies/` ancestor of `path`.
+
+    `/a/b/Proxies/sub/clip.mov` → `/a/b/Proxies`. None when the path has
+    no Proxies segment. Used to delete the whole proxy tree in one
+    files_delete_v2 call instead of file-by-file.
+    """
+    if not path:
+        return None
+    from pathlib import PurePosixPath
+    parts = PurePosixPath(path).parts
+    for i, seg in enumerate(parts):
+        if seg.lower() == _PROXIES_SEGMENT_NAME:
+            return str(PurePosixPath(*parts[: i + 1]))
+    return None
 
 
 # Codecs that ffprobe reports for files that are technically images

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -164,7 +164,11 @@ class DownloadWorker(BaseWorker):
         # in NEW state. Catch them here BEFORE wasting bandwidth on the
         # download — dispatcher feeds whatever's in NEW, regardless of
         # which scanner version queued it.
-        from .utils import path_has_assets_segment, path_is_in_proxies_folder
+        from .utils import (
+            path_has_assets_segment,
+            path_is_in_proxies_folder,
+            path_is_proxy_filename,
+        )
         if path_has_assets_segment(job.dropbox_path):
             logger.info(
                 f"[{self.name}] Skipping (under /assets/): {job.dropbox_path}"
@@ -179,13 +183,13 @@ class DownloadWorker(BaseWorker):
         # Proxies/ rule (or by an older scanner) must not burn bandwidth on
         # regenerable proxy files. The scanner handles the optional folder
         # delete; here we only refuse to download.
-        if path_is_in_proxies_folder(job.dropbox_path):
+        if path_is_in_proxies_folder(job.dropbox_path) or path_is_proxy_filename(job.dropbox_path):
             logger.info(
-                f"[{self.name}] Skipping (under Proxies/): {job.dropbox_path}"
+                f"[{self.name}] Skipping (camera/NLE proxy): {job.dropbox_path}"
             )
             self.db.update_job_state(
                 job.id, JobState.SKIPPED_EXCLUDED,
-                error_message="file under a Proxies/ folder — proxies are never transcoded",
+                error_message="camera/NLE proxy (proxy folder or _Proxy filename) — never transcoded",
             )
             return
 

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -1598,17 +1598,21 @@ class UploadWorker(BaseWorker):
 
         parent = str(PurePosixPath(just_finished_job.dropbox_path).parent)
 
-        # Gate 1: user activity (existing semantic)
+        # Gate 1: is the edit still active? Driven by the Premiere project's
+        # real save time (.prproj), falling back to the footage's real date.
         activity = is_folder_settled(
             self.dropbox, parent, self.config.legacy_reorganize_min_age_days,
+            dropbox_root=self.config.dropbox_root,
         )
         if not activity.settled:
             days = (f"{activity.days_since_newest:.1f}"
                     if activity.days_since_newest is not None else "?")
+            what = (".prproj saved" if getattr(activity, "source", "") == "prproj"
+                    else "footage")
             logger.info(
-                f"[{self.name}] Reorganize deferred ({parent}): folder activity "
-                f"{days}d old (< threshold {activity.threshold_days}d). "
-                f"Will retry after the next upload in this folder."
+                f"[{self.name}] Reorganize deferred ({parent}): {what} "
+                f"{days}d ago (< threshold {activity.threshold_days}d — project "
+                f"still active). Will retry after the next upload in this folder."
             )
             return
 

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -22,7 +22,11 @@ from typing import TYPE_CHECKING, Callable
 from .database import Database, Job, JobState
 from .disk_budget import DiskBudget
 from .dispatcher import JobDispatcher
-from .dropbox_client import DropboxClient, DropboxRevChangedError
+from .dropbox_client import (
+    DropboxClient,
+    DropboxNotFoundError,
+    DropboxRevChangedError,
+)
 from .encoder_detect import EncoderType, select_best_encoder
 from .ffmpeg_builder import FFmpegCommand, FFmpegCommandBuilder
 from .prober import ProbeError, ProbeResult, probe_video, validate_output
@@ -44,6 +48,16 @@ logger = logging.getLogger(__name__)
 
 # How long worker.queue.get() blocks before re-checking stop_event.
 _QUEUE_GET_TIMEOUT_SEC = 5.0
+
+# Error-message marker: the transcode output came up short (duration
+# mismatch) even though the input was SOFTWARE-decoded and ffmpeg exited 0.
+# Software decode is the most error-tolerant path we have, so a truncation
+# there means the source bitstream itself ends/breaks at that timestamp —
+# re-running can only re-produce the same bytes. TranscodeWorker
+# _handle_failure treats this prefix as terminal (SKIPPED_CORRUPT) instead
+# of burning GPU-hours on identical retries (HEAVY7: 4178.7s source died at
+# exactly 2157.4s on every attempt, ~35 min of QSV time per lap, forever).
+TRUNCATED_DESPITE_SW_DECODE = "Output truncated despite software decode:"
 
 
 class WorkerStop(Exception):
@@ -150,7 +164,7 @@ class DownloadWorker(BaseWorker):
         # in NEW state. Catch them here BEFORE wasting bandwidth on the
         # download — dispatcher feeds whatever's in NEW, regardless of
         # which scanner version queued it.
-        from .utils import path_has_assets_segment
+        from .utils import path_has_assets_segment, path_is_in_proxies_folder
         if path_has_assets_segment(job.dropbox_path):
             logger.info(
                 f"[{self.name}] Skipping (under /assets/): {job.dropbox_path}"
@@ -158,6 +172,20 @@ class DownloadWorker(BaseWorker):
             self.db.update_job_state(
                 job.id, JobState.SKIPPED_EXCLUDED,
                 error_message="path under /assets/ — project resources never transcoded",
+            )
+            return
+
+        # Same defensive gate for camera/NLE proxies: jobs queued before the
+        # Proxies/ rule (or by an older scanner) must not burn bandwidth on
+        # regenerable proxy files. The scanner handles the optional folder
+        # delete; here we only refuse to download.
+        if path_is_in_proxies_folder(job.dropbox_path):
+            logger.info(
+                f"[{self.name}] Skipping (under Proxies/): {job.dropbox_path}"
+            )
+            self.db.update_job_state(
+                job.id, JobState.SKIPPED_EXCLUDED,
+                error_message="file under a Proxies/ folder — proxies are never transcoded",
             )
             return
 
@@ -237,6 +265,10 @@ class DownloadWorker(BaseWorker):
                 f"{job.id}; resumes from the partial next window"
             )
             self.db.update_job_state(job.id, JobState.NEW)
+            if self.disk_budget is not None:
+                self.disk_budget.release(job.id)
+        except DropboxNotFoundError as e:
+            self._handle_not_found(job, e)
             if self.disk_budget is not None:
                 self.disk_budget.release(job.id)
         except Exception as e:
@@ -435,6 +467,10 @@ class DownloadWorker(BaseWorker):
                     job.dropbox_path, head_path, 0, chunk_bytes,
                 )
                 detected = probe_codec_from_file(head_path, self.config.ffprobe_path)
+            except DropboxNotFoundError:
+                # Source is gone — don't waste the tail probe + full download
+                # on the same 404. process_job terminal-skips the job.
+                raise
             except Exception as e:
                 logger.debug(f"[{self.name}] preflight head probe error: {e}")
 
@@ -445,6 +481,8 @@ class DownloadWorker(BaseWorker):
                         job.dropbox_path, tail_path, tail_start, chunk_bytes,
                     )
                     detected = probe_codec_from_file(tail_path, self.config.ffprobe_path)
+                except DropboxNotFoundError:
+                    raise
                 except Exception as e:
                     logger.debug(f"[{self.name}] preflight tail probe error: {e}")
 
@@ -549,6 +587,50 @@ class DownloadWorker(BaseWorker):
                     waited += 0.5
 
         return callback
+
+    def _handle_not_found(self, job: Job, error: Exception) -> None:
+        """The source path 404'd on Dropbox.
+
+        Files vanish from under queued jobs when the editors move/rename a
+        folder (or delete it) after the scan. A 404 is permanent for THIS
+        path — retrying re-runs the same doomed lookup, and the FAILED
+        auto-revive (v6.7.8) then resurrects the job forever (the HEAVY7
+        loop: 22 jobs cycling 404 → RETRY_WAIT → FAILED → revive).
+
+        One direct metadata lookup re-confirms the miss so a transient
+        glitch can't terminal-skip a live file; then the job goes to
+        SKIPPED_NOT_FOUND (terminal — auto-revive only touches FAILED).
+        If the file ever comes back, a move gives it a new rev, so the
+        scanner re-queues it as a fresh job (terminal states are excluded
+        from the unique active-path index).
+        """
+        still_missing = False
+        try:
+            still_missing = self.dropbox.get_metadata(job.dropbox_path) is None
+        except Exception as meta_err:
+            # Couldn't confirm (auth hiccup, network, rate limit) — keep the
+            # normal retry path rather than risk skipping a live file.
+            logger.debug(
+                f"[{self.name}] not-found confirmation probe failed "
+                f"(treating as transient): {meta_err}"
+            )
+
+        if not still_missing:
+            logger.error(f"[{self.name}] Download failed: {error}")
+            self._handle_failure(job, str(error))
+            return
+
+        logger.warning(
+            f"[{self.name}] Source gone from Dropbox — marking job {job.id} "
+            f"SKIPPED_NOT_FOUND (file moved/renamed/deleted after scan; the "
+            f"scanner re-queues it if it reappears): {job.dropbox_path}"
+        )
+        self.db.update_job_state(
+            job.id,
+            JobState.SKIPPED_NOT_FOUND,
+            error_message=str(error)[:500],
+        )
+        self._cleanup_staging_on_failure(job)
 
     def _handle_failure(self, job: Job, error: str) -> None:
         """Handle job failure with retry logic."""
@@ -807,6 +889,7 @@ class TranscodeWorker(BaseWorker):
         REGISTRY.update(self.name, encoder=encoder.value)
 
         # Run FFmpeg
+        audio_fallback_used = False
         success = self._run_ffmpeg(cmd, job)
 
         if not success and probe_result.video_info.has_audio:
@@ -815,6 +898,7 @@ class TranscodeWorker(BaseWorker):
             # `-an` and the substitution would be a no-op, just wasting
             # another failed launch).
             logger.warning(f"[{self.name}] Retrying with audio re-encode")
+            audio_fallback_used = True
             cmd = self.command_builder.build_audio_fallback_command(
                 input_path,
                 output_path,
@@ -841,9 +925,11 @@ class TranscodeWorker(BaseWorker):
                 encoder,
             )
             logger.info(f"[{self.name}] {cmd.description}")
+            audio_fallback_used = False
             success = self._run_ffmpeg(cmd, job)
             if not success and probe_result.video_info.has_audio:
                 logger.warning(f"[{self.name}] CPU retry with audio re-encode")
+                audio_fallback_used = True
                 cmd = self.command_builder.build_audio_fallback_command(
                     input_path,
                     output_path,
@@ -895,9 +981,58 @@ class TranscodeWorker(BaseWorker):
             self.config.ffprobe_path,
         )
 
+        duration_truncated = bool(error) and error.startswith("Duration mismatch")
+        if not is_valid and duration_truncated and "-hwaccel" in cmd.args:
+            # ffmpeg exited 0 but the output stops short of the source: the
+            # QSV/NVENC decoder hit a broken spot in the bitstream and bailed
+            # quietly. Deterministic — an identical retry truncates at the
+            # exact same timestamp. Software decode powers through most of
+            # these (error concealment), so re-run once in hybrid mode
+            # (sw decode + same HW encoder) before declaring the source
+            # corrupt.
+            logger.warning(
+                f"[{self.name}] Output truncated with hardware decode "
+                f"({error}) — retrying once with software decode"
+            )
+            if output_path.exists():
+                output_path.unlink()
+            build = (
+                self.command_builder.build_audio_fallback_command
+                if audio_fallback_used
+                else self.command_builder.build_transcode_command
+            )
+            cmd = build(
+                input_path,
+                output_path,
+                probe_result.video_info,
+                encoder,
+                force_sw_decode=True,
+            )
+            logger.info(f"[{self.name}] {cmd.description}")
+            logger.info(f"[{self.name}] ffmpeg cmd: {cmd.as_string()}")
+            # Refresh updated_at so the watchdog's transcode timeout clock
+            # restarts for the (slower) sw-decode pass.
+            self.db.update_job_state(job.id, JobState.TRANSCODING)
+            if not self._run_ffmpeg(cmd, job):
+                raise ValueError("FFmpeg transcode failed")
+            if cmd.temp_output_path.exists():
+                cmd.temp_output_path.replace(output_path)
+            is_valid, error = validate_output(
+                output_path,
+                probe_result.video_info.duration_sec,
+                self.config.ffprobe_path,
+            )
+            duration_truncated = bool(error) and error.startswith("Duration mismatch")
+
         if not is_valid:
             if output_path.exists():
                 output_path.unlink()
+            if duration_truncated:
+                # The input was software-decoded (natively — CPU/hybrid — or
+                # via the retry above) and the output STILL stops short: the
+                # source bitstream itself ends there. Marker prefix sends
+                # this to SKIPPED_CORRUPT in _handle_failure (terminal).
+                raise ValueError(f"{TRUNCATED_DESPITE_SW_DECODE} {error}")
             raise ValueError(f"Output validation failed: {error}")
 
         # Probe output for stats
@@ -1103,17 +1238,43 @@ class TranscodeWorker(BaseWorker):
 
     def _handle_failure(self, job: Job, error: str) -> None:
         """Handle job failure with retry logic."""
-        # ffprobe couldn't read the local file. The downloader already
-        # verified that local_size == dropbox_size before handing it off,
-        # so the bytes on Dropbox are themselves unreadable — re-downloading
-        # would copy the same broken bytes again. Send straight to
-        # SKIPPED_CORRUPT (terminal) so the auto-revive (v6.7.8) doesn't
-        # keep churning it every 10 minutes.
-        if error.startswith("Probe failed:"):
+        # Terminal corrupt-source shapes — retrying re-reads the same broken
+        # bytes, so send straight to SKIPPED_CORRUPT instead of letting the
+        # auto-revive (v6.7.8) churn them every 10 minutes:
+        #  - "Probe failed:": ffprobe can't read the local file at all. The
+        #    downloader already verified local_size == dropbox_size, so the
+        #    bytes on Dropbox are themselves unreadable.
+        #  - TRUNCATED_DESPITE_SW_DECODE: ffmpeg exited 0 but the output is
+        #    shorter than the source even with software decode — the
+        #    bitstream breaks at that timestamp on every attempt.
+        terminal_corrupt = error.startswith("Probe failed:") or error.startswith(
+            TRUNCATED_DESPITE_SW_DECODE
+        )
+        if terminal_corrupt:
             logger.warning(
                 f"[{self.name}] Marking job {job.id} as SKIPPED_CORRUPT "
-                f"(ffprobe can't read source, re-download won't help): {error}"
+                f"(source is unreadable/broken, retrying can't help): {error}"
             )
+            if (
+                self.incident_reporter is not None
+                and error.startswith(TRUNCATED_DESPITE_SW_DECODE)
+            ):
+                # GPU-hours were burned to discover this — surface it.
+                tail = ""
+                if self._last_ffmpeg_log:
+                    tail = self._tail_ffmpeg_log(self._last_ffmpeg_log, lines=30)
+                self.incident_reporter.report(
+                    kind="corrupt-skip",
+                    summary=f"Output truncated even with software decode — "
+                            f"skipping {Path(job.dropbox_path).name} as corrupt",
+                    log_tail=tail,
+                    context={
+                        "job_id": job.id,
+                        "dropbox_path": job.dropbox_path,
+                        "error": error,
+                        "worker": self.name,
+                    },
+                )
             self.db.update_job_state(
                 job.id,
                 JobState.SKIPPED_CORRUPT,

--- a/tests/test_folder_settled_prproj.py
+++ b/tests/test_folder_settled_prproj.py
@@ -1,0 +1,156 @@
+"""Reorganize/delete gate keyed on the Premiere project, not "file touched".
+
+Operator correction: the old `is_folder_settled` looked at whether ANY file in
+the media folder was modified in the last N days, using Dropbox's
+server_modified (upload time). That falsely froze reorganization whenever a
+batch of finished, years-old footage was merely re-synced to Dropbox — the
+upload reset the clock. The right signal is the Adobe Premiere project's real
+last-save time (.prproj, client_modified), found by walking up to the nearest
+delivery folder; with the footage's real capture date as the fallback when no
+project exists.
+"""
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from transcoder.dropbox_client import DropboxFileInfo  # noqa: E402
+from transcoder.reorganize import is_folder_settled  # noqa: E402
+
+ROOT = "/HD"
+
+
+def _file(folder, name, *, client_days_ago, server_days_ago=0):
+    now = datetime.now(timezone.utc)
+    return DropboxFileInfo(
+        path=f"{folder}/{name}",
+        name=name,
+        size=1,
+        rev="rev",
+        server_modified=now - timedelta(days=server_days_ago),
+        client_modified=now - timedelta(days=client_days_ago),
+    )
+
+
+class _FakeDbx:
+    """Serves a fixed {folder_path: [DropboxFileInfo]} tree, counting lists."""
+
+    def __init__(self, tree):
+        self.tree = tree
+        self.calls: list[str] = []
+
+    def list_folder(self, path, recursive=False):
+        self.calls.append(path)
+        for entry in self.tree.get(path, []):
+            yield entry
+
+
+# --- .prproj is the signal -------------------------------------------------------
+
+def test_recent_prproj_in_media_folder_holds():
+    dbx = _FakeDbx({
+        "/HD/proj": [
+            _file("/HD/proj", "edit.prproj", client_days_ago=3),
+            _file("/HD/proj", "C0001.MP4", client_days_ago=400),
+        ],
+    })
+    r = is_folder_settled(dbx, "/HD/proj", 60, dropbox_root=ROOT)
+    assert r.settled is False
+    assert r.source == "prproj"
+
+
+def test_old_prproj_lets_it_reorganize():
+    dbx = _FakeDbx({
+        "/HD/proj": [
+            _file("/HD/proj", "edit.prproj", client_days_ago=120),
+            _file("/HD/proj", "C0001.MP4", client_days_ago=400),
+        ],
+    })
+    r = is_folder_settled(dbx, "/HD/proj", 60, dropbox_root=ROOT)
+    assert r.settled is True
+    assert r.source == "prproj"
+
+
+def test_prproj_found_by_walking_up_to_delivery_folder():
+    # Media sits deep; the project lives at the delivery root above it.
+    dbx = _FakeDbx({
+        "/HD/proj": [_file("/HD/proj", "edit.prproj", client_days_ago=2)],
+        "/HD/proj/footage": [],
+        "/HD/proj/footage/day1": [
+            _file("/HD/proj/footage/day1", "C0001.MP4", client_days_ago=400),
+        ],
+    })
+    r = is_folder_settled(dbx, "/HD/proj/footage/day1", 60, dropbox_root=ROOT)
+    assert r.settled is False
+    assert r.source == "prproj"
+
+
+# --- the actual ingest bug: upload time must be ignored --------------------------
+
+def test_reuploaded_old_footage_is_settled_despite_recent_upload():
+    # No project anywhere. Footage shot 400d ago but re-synced to Dropbox today:
+    # server_modified is fresh, client_modified is old. Must read as settled.
+    dbx = _FakeDbx({
+        "/HD/archive": [
+            _file("/HD/archive", "C0001.MP4", client_days_ago=400, server_days_ago=0),
+            _file("/HD/archive", "C0002.MP4", client_days_ago=400, server_days_ago=0),
+        ],
+    })
+    r = is_folder_settled(dbx, "/HD/archive", 60, dropbox_root=ROOT)
+    assert r.settled is True
+    assert r.source == "media"
+
+
+def test_genuinely_recent_footage_without_project_holds():
+    dbx = _FakeDbx({
+        "/HD/fresh": [_file("/HD/fresh", "C0001.MP4", client_days_ago=5)],
+    })
+    r = is_folder_settled(dbx, "/HD/fresh", 60, dropbox_root=ROOT)
+    assert r.settled is False
+    assert r.source == "media"
+
+
+# --- edges -----------------------------------------------------------------------
+
+def test_min_age_zero_short_circuits():
+    dbx = _FakeDbx({"/HD/x": [_file("/HD/x", "edit.prproj", client_days_ago=0)]})
+    r = is_folder_settled(dbx, "/HD/x", 0, dropbox_root=ROOT)
+    assert r.settled is True
+    assert r.source == "disabled"
+    assert dbx.calls == []  # never even lists
+
+
+def test_empty_folder_is_settled():
+    dbx = _FakeDbx({"/HD/empty": []})
+    r = is_folder_settled(dbx, "/HD/empty", 60, dropbox_root=ROOT)
+    assert r.settled is True
+    assert r.source == "empty"
+
+
+def test_walkup_stops_at_dropbox_root():
+    # The only .prproj is ABOVE the configured root — must not be used.
+    dbx = _FakeDbx({
+        "/HD": [_file("/HD", "stray.prproj", client_days_ago=2)],
+        "/HD/proj/day1": [_file("/HD/proj/day1", "C0001.MP4", client_days_ago=400)],
+    })
+    r = is_folder_settled(dbx, "/HD/proj/day1", 60, dropbox_root="/HD/proj")
+    assert r.settled is True          # fell back to the old footage
+    assert r.source == "media"
+    assert "/HD" not in dbx.calls     # never climbed above the root
+
+
+def test_cache_avoids_relisting_shared_ancestors():
+    dbx = _FakeDbx({
+        "/HD/proj": [_file("/HD/proj", "edit.prproj", client_days_ago=2)],
+        "/HD/proj/footage": [],
+        "/HD/proj/footage/day1": [_file("/HD/proj/footage/day1", "A.MP4", client_days_ago=400)],
+        "/HD/proj/footage/day2": [_file("/HD/proj/footage/day2", "B.MP4", client_days_ago=400)],
+    })
+    cache: dict = {}
+    r1 = is_folder_settled(dbx, "/HD/proj/footage/day1", 60, dropbox_root=ROOT, cache=cache)
+    r2 = is_folder_settled(dbx, "/HD/proj/footage/day2", 60, dropbox_root=ROOT, cache=cache)
+    assert r1.settled is r2.settled is False
+    assert r1.source == r2.source == "prproj"
+    # The shared delivery folder is listed once, not once per sibling.
+    assert dbx.calls.count("/HD/proj") == 1

--- a/tests/test_manifest_per_pc.py
+++ b/tests/test_manifest_per_pc.py
@@ -112,19 +112,22 @@ class TestManifestPerPC:
 
     def test_cleanup_old_history(self, tmp_path):
         mgr = self._make_manager(tmp_path, "Heavy1")
+        from datetime import datetime, timedelta
         from transcoder.manifest import DailyProgress
+        # Dynamic date so the test doesn't rot out of the 90-day window.
+        recent = (datetime.now() - timedelta(days=5)).strftime('%Y-%m-%d')
         mgr.manifest.daily_history['2020-01-01'] = DailyProgress(
             date='2020-01-01', files_processed=1,
             bytes_processed=100, bytes_saved=50, by_pc={'Heavy1': 1},
         )
-        mgr.manifest.daily_history['2025-12-01'] = DailyProgress(
-            date='2025-12-01', files_processed=1,
+        mgr.manifest.daily_history[recent] = DailyProgress(
+            date=recent, files_processed=1,
             bytes_processed=100, bytes_saved=50, by_pc={'Heavy1': 1},
         )
         removed = mgr.cleanup_old_history(max_days=90)
         assert removed == 1
         assert '2020-01-01' not in mgr.manifest.daily_history
-        assert '2025-12-01' in mgr.manifest.daily_history
+        assert recent in mgr.manifest.daily_history
 
     def test_path_normalization(self, tmp_path):
         mgr = self._make_manager(tmp_path, "Heavy1")

--- a/tests/test_not_found_terminal.py
+++ b/tests/test_not_found_terminal.py
@@ -1,0 +1,207 @@
+"""Regression tests for the not-found retry loop (HEAVY7 field case).
+
+When a folder is moved/renamed/deleted on Dropbox after its files were
+queued, every download attempt 404s. Before the fix:
+  * download_partial converted the ApiError to DropboxNotFoundError INSIDE
+    its operation closure, so _retry_operation's generic handler retried the
+    permanent 404 with the full 2+4+8+16s backoff (the preflight retry storm);
+  * the worker treated the 404 as transient — RETRY_WAIT → FAILED — and the
+    watchdog's failed-revive then resurrected all of them forever.
+
+Now: DropboxNotFoundError short-circuits the retry loop, and the download
+worker re-confirms the miss with one metadata lookup and parks the job in
+SKIPPED_NOT_FOUND (terminal — the failed-revive only touches FAILED). A
+file that reappears gets a fresh job: terminal states are excluded from the
+unique active-path index and a Dropbox move produces a new rev.
+"""
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from transcoder.database import (  # noqa: E402
+    Database,
+    JobState,
+    TERMINAL_STATES,
+)
+
+
+# --- terminal-state plumbing ---------------------------------------------------
+
+def test_skipped_not_found_is_terminal():
+    assert JobState.SKIPPED_NOT_FOUND in TERMINAL_STATES
+
+
+def _make_db(tmp_path) -> Database:
+    db = Database(tmp_path / "jobs.db")
+    db.initialize()
+    return db
+
+
+def test_reappeared_file_can_be_requeued_after_not_found(tmp_path):
+    """A SKIPPED_NOT_FOUND row must not block a fresh job for the same path
+    (unique active-path index excludes terminal states)."""
+    db = _make_db(tmp_path)
+    job = db.create_job(
+        dropbox_path="/HD/folder/clip.mp4",
+        dropbox_rev="rev-1",
+        dropbox_size=123,
+        output_path="/HD/folder/h265/clip.mp4",
+        state=JobState.NEW,
+    )
+    db.update_job_state(job.id, JobState.SKIPPED_NOT_FOUND)
+
+    # File came back (move back = new rev) — scanner creates a new job.
+    new_job = db.create_job(
+        dropbox_path="/HD/folder/clip.mp4",
+        dropbox_rev="rev-2",
+        dropbox_size=123,
+        output_path="/HD/folder/h265/clip.mp4",
+        state=JobState.NEW,
+    )
+    assert new_job is not None
+    assert new_job.id != job.id
+    assert new_job.state == JobState.NEW
+
+
+def test_failed_revive_does_not_touch_skipped_not_found(tmp_path):
+    """The watchdog's reset_failed_jobs only revives FAILED — the whole point
+    of the terminal state is escaping that loop."""
+    db = _make_db(tmp_path)
+    nf_job = db.create_job(
+        dropbox_path="/HD/a/gone.mp4",
+        dropbox_rev="r1",
+        dropbox_size=1,
+        output_path="/HD/a/h265/gone.mp4",
+        state=JobState.NEW,
+    )
+    db.update_job_state(nf_job.id, JobState.SKIPPED_NOT_FOUND)
+    failed_job = db.create_job(
+        dropbox_path="/HD/a/flaky.mp4",
+        dropbox_rev="r1",
+        dropbox_size=1,
+        output_path="/HD/a/h265/flaky.mp4",
+        state=JobState.NEW,
+    )
+    db.update_job_state(failed_job.id, JobState.FAILED)
+
+    reset = db.reset_failed_jobs()
+
+    assert reset == 1
+    assert db.get_job(nf_job.id).state == JobState.SKIPPED_NOT_FOUND
+    assert db.get_job(failed_job.id).state == JobState.RETRY_WAIT
+
+
+# --- _retry_operation must not retry a permanent 404 ---------------------------
+
+def test_retry_operation_does_not_retry_dropbox_not_found(monkeypatch):
+    from transcoder.dropbox_client import DropboxClient, DropboxNotFoundError
+
+    client = object.__new__(DropboxClient)
+    client.max_retries = 5
+    client.retry_delay = 2.0
+    client.rate_limiter = None
+
+    calls = {"n": 0}
+
+    def op():
+        calls["n"] += 1
+        # The shape download_partial produces: already-converted not-found.
+        raise DropboxNotFoundError("/HD/gone/file.mp4")
+
+    monkeypatch.setattr(time, "sleep", lambda *_a, **_k: pytest.fail(
+        "retry backoff slept on a permanent not-found"
+    ))
+
+    with pytest.raises(DropboxNotFoundError):
+        client._retry_operation(op, "download_partial(/HD/gone/file.mp4, 0+16777216)")
+
+    assert calls["n"] == 1, "expected exactly one attempt, no retries"
+
+
+# --- DownloadWorker._handle_not_found ------------------------------------------
+
+class _FakeDB:
+    def __init__(self):
+        self.updates: list[tuple[int, JobState, dict]] = []
+        self.retry_calls = 0
+
+    def update_job_state(self, job_id, state, **kw):
+        self.updates.append((job_id, state, kw))
+
+    def increment_retry(self, job_id, max_retries):
+        self.retry_calls += 1
+        return (1, False)  # always "retry again"
+
+    @property
+    def last_state(self):
+        return self.updates[-1][1]
+
+
+def _bare_download_worker(tmp_path, metadata_result):
+    """DownloadWorker with just the attributes _handle_not_found touches."""
+    import threading
+
+    from transcoder.workers import DownloadWorker
+
+    worker = object.__new__(DownloadWorker)
+    # Workers are Thread subclasses; the name property needs Thread.__init__.
+    threading.Thread.__init__(worker, name="downloader-test", daemon=True)
+    worker.db = _FakeDB()
+    worker.config = SimpleNamespace(
+        watchdog=SimpleNamespace(max_retries=10),
+        local_staging_dir=tmp_path,
+    )
+
+    class _FakeDropbox:
+        def get_metadata(self, path):
+            if isinstance(metadata_result, Exception):
+                raise metadata_result
+            return metadata_result
+
+    worker.dropbox = _FakeDropbox()
+    return worker
+
+
+def _job():
+    return SimpleNamespace(id=42, dropbox_path="/HD/x/clip.mp4", dropbox_size=100)
+
+
+def test_confirmed_missing_goes_terminal(tmp_path):
+    from transcoder.dropbox_client import DropboxNotFoundError
+
+    worker = _bare_download_worker(tmp_path, metadata_result=None)
+    worker._handle_not_found(_job(), DropboxNotFoundError("Path not found: x"))
+
+    assert worker.db.last_state == JobState.SKIPPED_NOT_FOUND
+    assert worker.db.retry_calls == 0, "terminal skip must not burn a retry"
+
+
+def test_metadata_says_alive_falls_back_to_retry(tmp_path):
+    """A 404 mid-download but the file still exists (transient/namespace
+    glitch) → normal retry machinery, NOT a terminal skip."""
+    from transcoder.dropbox_client import DropboxNotFoundError
+
+    worker = _bare_download_worker(
+        tmp_path, metadata_result=SimpleNamespace(size=100, rev="r1"),
+    )
+    worker._handle_not_found(_job(), DropboxNotFoundError("Path not found: x"))
+
+    assert worker.db.last_state == JobState.RETRY_WAIT
+    assert worker.db.retry_calls == 1
+
+
+def test_metadata_probe_error_falls_back_to_retry(tmp_path):
+    """Couldn't even confirm (network/auth hiccup) → keep retrying rather
+    than risk terminal-skipping a live file."""
+    from transcoder.dropbox_client import DropboxNotFoundError
+
+    worker = _bare_download_worker(tmp_path, metadata_result=RuntimeError("boom"))
+    worker._handle_not_found(_job(), DropboxNotFoundError("Path not found: x"))
+
+    assert worker.db.last_state == JobState.RETRY_WAIT
+    assert worker.db.retry_calls == 1

--- a/tests/test_proxies_skip.py
+++ b/tests/test_proxies_skip.py
@@ -120,6 +120,7 @@ def _bare_scanner(delete_on: bool, min_age_days: int = 30):
     )
     scanner.dropbox = _FakeDropbox()
     scanner._deleted_proxy_dirs = set()
+    scanner._settled_prproj_cache = {}
     return scanner
 
 
@@ -132,7 +133,7 @@ def test_settled_proxies_folder_deleted_once_for_all_siblings(monkeypatch):
 
     monkeypatch.setattr(
         scanner_mod, "_is_folder_settled",
-        lambda dbx, parent, min_age: SimpleNamespace(
+        lambda dbx, parent, min_age, **kw: SimpleNamespace(
             settled=True, days_since_newest=42.0, threshold_days=min_age,
         ),
     )
@@ -155,7 +156,7 @@ def test_hot_proxies_folder_is_deferred(monkeypatch):
 
     monkeypatch.setattr(
         scanner_mod, "_is_folder_settled",
-        lambda dbx, parent, min_age: SimpleNamespace(
+        lambda dbx, parent, min_age, **kw: SimpleNamespace(
             settled=False, days_since_newest=2.0, threshold_days=min_age,
         ),
     )

--- a/tests/test_proxies_skip.py
+++ b/tests/test_proxies_skip.py
@@ -94,6 +94,13 @@ def test_download_worker_skips_queued_proxy_job():
 
 # --- scanner: whole-folder delete -------------------------------------------------
 
+def test_delete_throwaway_is_on_by_default():
+    """Operator decision (Transcoder 11): always on. The folder-age gate
+    (legacy_reorganize_min_age_days, default 60d) is the only brake."""
+    from transcoder.config import ScannerSettings
+
+    assert ScannerSettings().delete_throwaway_files is True
+
 class _FakeDropbox:
     def __init__(self):
         self.deleted: list[str] = []

--- a/tests/test_proxies_skip.py
+++ b/tests/test_proxies_skip.py
@@ -1,0 +1,180 @@
+"""Tests for the Proxies/ folder rules.
+
+Operator request (Transcoder 11): "we don't need to spend time on proxies —
+delete the Proxies folder once it's older than X days." Three behaviors:
+
+  1. ANY file under a `Proxies/` folder is throwaway (until v7.7.x only
+     Sony-named `*_Proxy.*` files were matched, so Premiere/DaVinci proxies
+     slipped through and were downloaded + transcoded).
+  2. The download worker defensively skips proxy jobs already in the queue
+     (queued before the rule / by an older scanner).
+  3. When scanner.delete_throwaway_files is on, the WHOLE Proxies/ folder is
+     deleted in one call — gated by the same folder-age check reorganize
+     uses, so active edits are never touched.
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from transcoder.database import JobState  # noqa: E402
+from transcoder.utils import (  # noqa: E402
+    path_is_in_proxies_folder,
+    proxies_folder_root,
+)
+
+
+# --- path helpers ---------------------------------------------------------------
+
+def test_sony_style_proxy_matches():
+    assert path_is_in_proxies_folder("/HD/card1/Proxies/C8547_Proxy.mov")
+
+
+def test_any_file_under_proxies_matches():
+    # Premiere "Create proxies" output doesn't follow the Sony _Proxy naming.
+    assert path_is_in_proxies_folder("/HD/2025-11-13 venus/video/sd1/Proxies/C8547.mov")
+
+
+def test_nested_proxies_subfolder_matches():
+    assert path_is_in_proxies_folder("/HD/x/Proxies/1080p/clip.mov")
+
+
+def test_case_insensitive():
+    assert path_is_in_proxies_folder("/HD/x/PROXIES/clip.mov")
+    assert path_is_in_proxies_folder("/HD/x/proxies/clip.mov")
+
+
+def test_non_proxies_paths_do_not_match():
+    assert not path_is_in_proxies_folder("/HD/x/MyProxies/clip.mov")
+    assert not path_is_in_proxies_folder("/HD/x/video/clip_Proxy.mov")
+    assert not path_is_in_proxies_folder("")
+
+
+def test_proxies_folder_root_resolution():
+    assert proxies_folder_root("/HD/a/Proxies/c.mov") == "/HD/a/Proxies"
+    assert proxies_folder_root("/HD/a/Proxies/sub/c.mov") == "/HD/a/Proxies"
+    # Outermost Proxies wins (delete takes the whole tree anyway)
+    assert proxies_folder_root("/HD/Proxies/x/Proxies/c.mov") == "/HD/Proxies"
+    assert proxies_folder_root("/HD/a/video/c.mov") is None
+
+
+# --- download worker defensive skip ----------------------------------------------
+
+class _FakeDB:
+    def __init__(self):
+        self.updates = []
+
+    def update_job_state(self, job_id, state, **kw):
+        self.updates.append((job_id, state, kw))
+
+
+def test_download_worker_skips_queued_proxy_job():
+    import threading
+
+    from transcoder.workers import DownloadWorker
+
+    worker = object.__new__(DownloadWorker)
+    # Workers are Thread subclasses; the name property needs Thread.__init__.
+    threading.Thread.__init__(worker, name="downloader-test", daemon=True)
+    worker.db = _FakeDB()
+
+    job = SimpleNamespace(
+        id=1553,
+        dropbox_path="/HeavyDrops/2025-11-13 venus day talks/video/sd1/Proxies/C8547_Proxy.mov",
+        dropbox_size=576_480_000,
+    )
+    worker.process_job(job)
+
+    assert worker.db.updates, "job must be parked, not downloaded"
+    job_id, state, kw = worker.db.updates[-1]
+    assert state == JobState.SKIPPED_EXCLUDED
+    assert "Proxies" in kw.get("error_message", "")
+
+
+# --- scanner: whole-folder delete -------------------------------------------------
+
+class _FakeDropbox:
+    def __init__(self):
+        self.deleted: list[str] = []
+
+    def delete_file(self, path: str) -> bool:
+        self.deleted.append(path)
+        return True
+
+
+def _bare_scanner(delete_on: bool, min_age_days: int = 30):
+    from transcoder.scanner import Scanner
+
+    scanner = object.__new__(Scanner)
+    scanner.config = SimpleNamespace(
+        scanner=SimpleNamespace(delete_throwaway_files=delete_on),
+        legacy_reorganize_min_age_days=min_age_days,
+    )
+    scanner.dropbox = _FakeDropbox()
+    scanner._deleted_proxy_dirs = set()
+    return scanner
+
+
+def _entry(path: str):
+    return SimpleNamespace(path=path)
+
+
+def test_settled_proxies_folder_deleted_once_for_all_siblings(monkeypatch):
+    import transcoder.scanner as scanner_mod
+
+    monkeypatch.setattr(
+        scanner_mod, "_is_folder_settled",
+        lambda dbx, parent, min_age: SimpleNamespace(
+            settled=True, days_since_newest=42.0, threshold_days=min_age,
+        ),
+    )
+    scanner = _bare_scanner(delete_on=True)
+
+    r1 = scanner._process_file(
+        _entry("/HD/x/video/sd1/Proxies/C8547_Proxy.mov"), False, None,
+    )
+    r2 = scanner._process_file(
+        _entry("/HD/x/video/sd1/Proxies/C8723_Proxy.mov"), False, None,
+    )
+
+    assert r1 == r2 == "skipped_excluded"
+    # One delete, targeting the FOLDER — not two file deletes.
+    assert scanner.dropbox.deleted == ["/HD/x/video/sd1/Proxies"]
+
+
+def test_hot_proxies_folder_is_deferred(monkeypatch):
+    import transcoder.scanner as scanner_mod
+
+    monkeypatch.setattr(
+        scanner_mod, "_is_folder_settled",
+        lambda dbx, parent, min_age: SimpleNamespace(
+            settled=False, days_since_newest=2.0, threshold_days=min_age,
+        ),
+    )
+    scanner = _bare_scanner(delete_on=True)
+
+    result = scanner._process_file(
+        _entry("/HD/x/Proxies/C0001_Proxy.mov"), False, None,
+    )
+
+    assert result == "skipped_excluded"
+    assert scanner.dropbox.deleted == [], "active edit must never be deleted"
+
+
+def test_delete_off_only_skips(monkeypatch):
+    scanner = _bare_scanner(delete_on=False)
+
+    result = scanner._process_file(_entry("/HD/x/Proxies/c.mov"), False, None)
+
+    assert result == "skipped_excluded"
+    assert scanner.dropbox.deleted == []
+
+
+def test_dry_run_never_deletes():
+    scanner = _bare_scanner(delete_on=True)
+
+    result = scanner._process_file(_entry("/HD/x/Proxies/c.mov"), True, None)
+
+    assert result == "skipped_excluded"
+    assert scanner.dropbox.deleted == []

--- a/tests/test_proxies_skip.py
+++ b/tests/test_proxies_skip.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from transcoder.database import JobState  # noqa: E402
 from transcoder.utils import (  # noqa: E402
     path_is_in_proxies_folder,
+    path_is_proxy_filename,
     proxies_folder_root,
 )
 
@@ -59,6 +60,88 @@ def test_proxies_folder_root_resolution():
     assert proxies_folder_root("/HD/a/video/c.mov") is None
 
 
+# --- singular proxy/ folder + Sony _Proxy.* filename (v8.0.0) --------------------
+
+def test_singular_proxy_folder_matches():
+    # The HEAVY7 log case: /video/cam 03/proxy/C0462_Proxy.mov (singular folder).
+    assert path_is_in_proxies_folder("/HD/x/video/cam 03/proxy/C0462_Proxy.mov")
+    assert path_is_in_proxies_folder("/HD/x/PROXY/clip.mov")
+    assert proxies_folder_root("/HD/x/video/cam 03/proxy/C0462_Proxy.mov") == "/HD/x/video/cam 03/proxy"
+
+
+def test_proxy_filename_suffix_matches():
+    # Sony proxy dropped next to originals (no proxy folder).
+    assert path_is_proxy_filename("/HD/x/video/C0462_Proxy.mov")
+    assert path_is_proxy_filename("/HD/x/C0462_PROXY.MP4")
+    # Needs the "_" separator — a real clip just containing "proxy" must not match.
+    assert not path_is_proxy_filename("/HD/x/approxy.mov")
+    assert not path_is_proxy_filename("/HD/x/C0462.MP4")
+    assert not path_is_proxy_filename("")
+
+
+def test_download_worker_skips_loose_proxy_filename():
+    import threading
+
+    from transcoder.workers import DownloadWorker
+
+    worker = object.__new__(DownloadWorker)
+    threading.Thread.__init__(worker, name="downloader-test", daemon=True)
+    worker.db = _FakeDB()
+
+    # _Proxy file NOT inside a proxy folder — must still be skipped.
+    job = SimpleNamespace(
+        id=1771,
+        dropbox_path="/HeavyDrops/Arbitragem/.../video/cam 03/C0462_Proxy.mov",
+        dropbox_size=25_000_000,
+    )
+    worker.process_job(job)
+
+    assert worker.db.updates, "loose _Proxy file must be parked, not downloaded"
+    _, state, kw = worker.db.updates[-1]
+    assert state == JobState.SKIPPED_EXCLUDED
+    assert "proxy" in kw.get("error_message", "").lower()
+
+
+def test_singular_proxy_folder_deleted_whole(monkeypatch):
+    import transcoder.scanner as scanner_mod
+
+    monkeypatch.setattr(
+        scanner_mod, "_is_folder_settled",
+        lambda dbx, parent, min_age, **kw: SimpleNamespace(
+            settled=True, days_since_newest=99.0, threshold_days=min_age,
+        ),
+    )
+    scanner = _bare_scanner(delete_on=True)
+
+    result = scanner._process_file(
+        _entry("/HD/x/video/cam 03/proxy/C0462_Proxy.mov"), False, None,
+    )
+
+    assert result == "skipped_excluded"
+    # Deletes the whole singular proxy/ folder, not the single file.
+    assert scanner.dropbox.deleted == ["/HD/x/video/cam 03/proxy"]
+
+
+def test_loose_proxy_file_deleted_file_by_file(monkeypatch):
+    import transcoder.scanner as scanner_mod
+
+    monkeypatch.setattr(
+        scanner_mod, "_is_folder_settled",
+        lambda dbx, parent, min_age, **kw: SimpleNamespace(
+            settled=True, days_since_newest=99.0, threshold_days=min_age,
+        ),
+    )
+    scanner = _bare_scanner(delete_on=True)
+
+    # _Proxy file with no proxy folder → delete just the file, not the parent.
+    result = scanner._process_file(
+        _entry("/HD/x/video/cam 03/C0462_Proxy.mov"), False, None,
+    )
+
+    assert result == "skipped_excluded"
+    assert scanner.dropbox.deleted == ["/HD/x/video/cam 03/C0462_Proxy.mov"]
+
+
 # --- download worker defensive skip ----------------------------------------------
 
 class _FakeDB:
@@ -89,7 +172,7 @@ def test_download_worker_skips_queued_proxy_job():
     assert worker.db.updates, "job must be parked, not downloaded"
     job_id, state, kw = worker.db.updates[-1]
     assert state == JobState.SKIPPED_EXCLUDED
-    assert "Proxies" in kw.get("error_message", "")
+    assert "proxy" in kw.get("error_message", "").lower()
 
 
 # --- scanner: whole-folder delete -------------------------------------------------

--- a/tests/test_truncated_transcode.py
+++ b/tests/test_truncated_transcode.py
@@ -1,0 +1,172 @@
+"""Regression tests for the deterministic truncated-transcode loop.
+
+HEAVY7 field case: hevc_qsv transcode of a 4178.7s file exited 0 but the
+output stopped at exactly 2157.4s on EVERY attempt — the QSV decoder hit a
+broken spot in the bitstream and bailed quietly. The old pipeline treated
+the "Output validation failed: Duration mismatch" as transient and re-ran
+the identical command forever (~35 min of GPU per lap).
+
+New behavior:
+  * first truncation with hardware decode → one in-line retry with software
+    decode (hybrid mode: sw decode + same HW encoder), which usually powers
+    through corrupt regions;
+  * truncation despite software decode → terminal SKIPPED_CORRUPT via the
+    TRUNCATED_DESPITE_SW_DECODE error marker.
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from transcoder.database import JobState  # noqa: E402
+from transcoder.encoder_detect import EncoderType  # noqa: E402
+from transcoder.ffmpeg_builder import FFmpegCommandBuilder, VideoInfo  # noqa: E402
+
+
+def _video_info(**overrides) -> VideoInfo:
+    base = dict(
+        codec_name="h264",
+        width=1920,
+        height=1080,
+        fps=29.97,
+        duration_sec=4178.7,
+        bitrate_kbps=20_000,
+        bit_depth=8,
+        chroma="420",
+        has_audio=True,
+    )
+    base.update(overrides)
+    return VideoInfo(**base)
+
+
+def _config():
+    from transcoder.config import TranscodeProfile
+
+    return SimpleNamespace(
+        profile=TranscodeProfile.QUALITY,
+        ffmpeg_path="ffmpeg",
+        gop_size=60,
+        ffmpeg_extra_args=[],
+        cq_value=26,
+        preserve_chroma_422=False,
+        cpu_crf_equivalent=23,
+        bitrate=SimpleNamespace(target_mbps=40, max_mbps=60, bufsize_mbps=120),
+        audio_fallback_codec="aac",
+        audio_fallback_bitrate="256k",
+    )
+
+
+# --- builder: force_sw_decode --------------------------------------------------
+
+def test_qsv_default_uses_hw_decode(tmp_path):
+    builder = FFmpegCommandBuilder(_config())
+    cmd = builder.build_transcode_command(
+        tmp_path / "in.mp4", tmp_path / "out.mp4", _video_info(), EncoderType.QSV,
+    )
+    assert "-hwaccel" in cmd.args
+    assert "hevc_qsv" in cmd.args
+
+
+def test_force_sw_decode_drops_hwaccel_keeps_hw_encoder(tmp_path):
+    builder = FFmpegCommandBuilder(_config())
+    cmd = builder.build_transcode_command(
+        tmp_path / "in.mp4", tmp_path / "out.mp4", _video_info(), EncoderType.QSV,
+        force_sw_decode=True,
+    )
+    assert "-hwaccel" not in cmd.args, "sw decode must not init the hw decoder"
+    assert "hevc_qsv" in cmd.args, "the ENCODER stays hardware (hybrid mode)"
+    # sw-decoded frames need the explicit format bridge to the hw encoder
+    assert "-vf" in cmd.args
+    vf = cmd.args[cmd.args.index("-vf") + 1]
+    assert vf.startswith("format=")
+    assert "(forced sw decode)" in cmd.description
+
+
+def test_force_sw_decode_audio_fallback_passthrough(tmp_path):
+    builder = FFmpegCommandBuilder(_config())
+    cmd = builder.build_audio_fallback_command(
+        tmp_path / "in.mp4", tmp_path / "out.mp4", _video_info(), EncoderType.QSV,
+        force_sw_decode=True,
+    )
+    assert "-hwaccel" not in cmd.args
+    assert "aac" in cmd.args, "audio re-encode preserved on the sw-decode retry"
+
+
+def test_force_sw_decode_noop_for_cpu(tmp_path):
+    builder = FFmpegCommandBuilder(_config())
+    cmd = builder.build_transcode_command(
+        tmp_path / "in.mp4", tmp_path / "out.mp4", _video_info(), EncoderType.CPU,
+        force_sw_decode=True,
+    )
+    assert "-hwaccel" not in cmd.args
+    assert "libx265" in cmd.args
+
+
+# --- TranscodeWorker._handle_failure classification ----------------------------
+
+class _FakeDB:
+    def __init__(self):
+        self.updates = []
+        self.retry_calls = 0
+
+    def update_job_state(self, job_id, state, **kw):
+        self.updates.append((job_id, state, kw))
+
+    def increment_retry(self, job_id, max_retries):
+        self.retry_calls += 1
+        return (1, False)
+
+    @property
+    def last_state(self):
+        return self.updates[-1][1]
+
+
+def _bare_transcode_worker():
+    import threading
+
+    from transcoder.workers import TranscodeWorker
+
+    worker = object.__new__(TranscodeWorker)
+    # Workers are Thread subclasses; the name property needs Thread.__init__.
+    threading.Thread.__init__(worker, name="transcoder-test", daemon=True)
+    worker.db = _FakeDB()
+    worker.config = SimpleNamespace(watchdog=SimpleNamespace(max_retries=10))
+    worker.disk_budget = None
+    worker.incident_reporter = None
+    worker._last_ffmpeg_log = None
+    return worker
+
+
+def _job():
+    return SimpleNamespace(id=17610, dropbox_path="/HD/x/MAIN.mp4", local_input_path=None)
+
+
+def test_truncated_despite_sw_decode_is_terminal_corrupt():
+    from transcoder.workers import TRUNCATED_DESPITE_SW_DECODE
+
+    worker = _bare_transcode_worker()
+    worker._handle_failure(
+        _job(),
+        f"{TRUNCATED_DESPITE_SW_DECODE} Duration mismatch: expected 4178.7s, "
+        f"got 2157.4s (diff 2021.4s > 41.8s)",
+    )
+    assert worker.db.last_state == JobState.SKIPPED_CORRUPT
+    assert worker.db.retry_calls == 0
+
+
+def test_probe_failed_still_terminal_corrupt():
+    worker = _bare_transcode_worker()
+    worker._handle_failure(_job(), "Probe failed: moov atom not found")
+    assert worker.db.last_state == JobState.SKIPPED_CORRUPT
+
+
+def test_plain_validation_failure_still_retries():
+    """Only the explicit sw-decode marker is terminal — a bare validation
+    failure (e.g. before the sw retry ran) keeps the retry path."""
+    worker = _bare_transcode_worker()
+    worker._handle_failure(
+        _job(), "Output validation failed: Output file is empty",
+    )
+    assert worker.db.last_state == JobState.RETRY_WAIT
+    assert worker.db.retry_calls == 1

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.9.0
+HeavyDrops Transcoder v8.0.0
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.9.0"
+VERSION = "8.0.0"
 
 import socket
 import subprocess

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.8.0
+HeavyDrops Transcoder v7.9.0
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.8.0"
+VERSION = "7.9.0"
 
 import socket
 import subprocess

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v7.7.3
+HeavyDrops Transcoder v7.8.0
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "7.7.3"
+VERSION = "7.8.0"
 
 import socket
 import subprocess


### PR DESCRIPTION
## v7.9.0 — reorganize + Proxies/ delete now follow the Premiere project, not "file touched"

Operator correction from the field: the "is this folder still being edited?" gate was using the wrong concept. It deferred reorganize **and** Proxies/ deletion based on whether *any file in the media folder* was modified recently — measured by Dropbox **`server_modified` (upload time)**. So re-syncing a batch of finished, years-old footage (e.g. 2021 camera files) reset the clock and **froze the pipeline forever**: the H.265 stayed under `/h265/`, the `/h264` backup was never reclaimed, and `Proxies/` never got cleaned. This is what kept the recent folders on HEAVY7 "open" even though the footage was old.

**Now the signal is the Adobe Premiere project (`.prproj`):**
- Walk up from the media folder to the **nearest delivery folder** holding a `.prproj` and use that project's **real last-save time (`client_modified`)**. Saved < threshold (60d default) ⇒ still being edited ⇒ hold. Older ⇒ release (swap H.265 in, delete `/h264`, delete `Proxies/`).
- If **no `.prproj`** exists anywhere up to `dropbox_root`, fall back to the **footage's real capture date** (`client_modified`) of the media in the folder.
- Uses `client_modified` (the real on-disk date) **everywhere**, never `server_modified` — re-uploading an old archive can no longer freeze the pipeline.

Applies identically to: the live reorganize defer (`workers.py`), the `reorganize-existing` CLI, the dashboard reorganize preview, and the **whole-folder `Proxies/` delete**. A caller-owned per-pass cache avoids re-listing shared ancestors across sibling media folders.

`DropboxFileInfo` gains `client_modified`. New `tests/test_folder_settled_prproj.py` covers the `.prproj` signal (recent vs old), walk-up to the delivery folder, the re-upload bug (recent `server_modified` + old `client_modified` ⇒ settled), the media fallback, the `dropbox_root` ceiling, the disabled/empty edges, and the ancestor cache. **130 passed.**

Bump 7.8.0 → 7.9.0.

> Note for the fleet: HEAVY7 is still on **v7.00**, which predates the cross-machine claim (v7.5.0) and all of the below — it needs a `git pull` + restart to get any of this.

---

## v7.8.0 (earlier on this branch)

Field report from HEAVY7 ("Transcoder 11 – Transcend"): two infinite retry loops in the log, plus the operator request to stop spending time on proxies.

### 1. Downloads of files that vanished from Dropbox looped forever
A folder moved/renamed/deleted after the scan left ~22 jobs cycling: every attempt 404'd (`GetMetadataError(path, not_found)`), smart-retry rescheduled, jobs went FAILED, and the watchdog failed-revive resurrected all of them — forever, flooding the log.

- `_retry_operation` no longer retries `DropboxNotFoundError` — the preflight `download_partial` was burning the full 2+4+8+16s backoff on every 404 (the conversion happened *inside* the operation closure, dodging the existing ApiError short-circuit).
- The download worker re-confirms the miss with one `get_metadata` call, then parks the job in the terminal **`SKIPPED_NOT_FOUND`** state (failed-revive only touches FAILED). If the metadata probe says the file is alive (transient glitch), the normal retry path is kept.
- If the file reappears, the scanner re-queues it: a Dropbox move produces a new rev, and terminal states are excluded from the unique active-path index.

### 2. Transcode of a source with a broken bitstream looped forever
`hevc_qsv` bailed quietly mid-file (ffmpeg exit 0): output validation failed with the **same duration on every attempt**, ~35 min of GPU per lap, retried identically forever.

- First truncation with hardware decode → one in-line retry with **software decode** (`force_sw_decode`: sw decode + same HW encoder, the existing hybrid-mode path).
- Truncated even with software decode → the source bitstream genuinely breaks → terminal `SKIPPED_CORRUPT` + an auto-incident with the ffmpeg.log tail.

### 3. Proxies
- **Anything** under a `Proxies/` folder is throwaway now — previously only Sony-named `*_Proxy.*` matched, so Premiere/DaVinci proxies were downloaded + transcoded.
- The download worker defensively skips proxy jobs already queued by an older scanner.
- `delete_throwaway_files` deletes the **whole `Proxies/` folder in one call**, **ON by default**, gated by the settled check (now the v7.9.0 project-based one). Recoverable via Dropbox version history ~30 days.
- Dashboard toggle to turn it OFF per machine.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVoxfM3HMdZ4Nu1i5aB6T1