### PR TITLE
v8.1.0: watchdog kills stuck processes + stable timeout clock + budget self-heal + ranged downloads

### DIFF
--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,42 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versão: 8.1.0
+Data: 14/07/2026
+--------------------------------------------------------------------------------
+
+Watchdog agora MATA processo travado (fim do transcode-zumbi de 6 dias)
+
+  [FIX] O relógio de timeout do watchdog usava updated_at — mas um trigger
+        do SQLite atualiza updated_at em QUALQUER escrita na linha do job
+        (progresso, retry). Um ffmpeg quase congelado que pinga progresso
+        resetava o próprio cronômetro pra sempre: na HEAVY7, dois transcodes
+        rodaram 6+ dias sem nunca estourar o timeout de 24h. Novo carimbo
+        state_changed_at é escrito SÓ na transição de estado (com migração
+        automática do banco) e passa a ser o relógio do timeout e do backoff.
+  [FEATURE] Timeout agora mata o processo em voo de verdade: o watchdog
+        pede ao worker dono do job pra terminar o ffmpeg (ou abortar o
+        stream de download), a thread destrava e o caminho normal de falha
+        faz a limpeza (retry, RETRY_WAIT/FAILED, libera reserva de disco,
+        apaga staging). Job órfão (sem worker) ou kill que não destravou em
+        2 tentativas: o watchdog assume, requeueia e libera a reserva ele
+        mesmo.
+  [FIX] Reservas do disk budget órfãs eram limpas SÓ no boot; um vazamento
+        (crash de worker, kill -9) travava o budget até o próximo restart —
+        os 3 dias de "staging budget exhausted" com 1.82 TB reservado e ZERO
+        trabalho feito. O watchdog agora reconcilia as reservas a cada
+        ciclo (60s): reserva de job não-ativo é reclamada sozinha.
+  [FIX] Job.from_row não repassava a coluna kind — todo job lido do banco
+        virava "video" e a fila de áudio (WAV→MP3) nunca era alimentada
+        pelo dispatcher. Áudio volta a rotear certo.
+  [FIX] Download em faixas de 2 GB (byte-range) em vez de um stream único:
+        a conexão do Dropbox caía consistentemente perto dos ~10 GB
+        (IncompleteRead) e cada queda custava um ciclo inteiro de retry.
+        Agora nenhuma conexão vive o bastante pra cair, e uma quebra no
+        meio reconecta na hora do byte exato, sem falhar o job.
+
+--------------------------------------------------------------------------------
+
 Versão: 8.0.0
 Data: 25/06/2026
 --------------------------------------------------------------------------------

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "8.0.0"
+#define MyAppVersion "8.1.0"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v8.0.0 Installer
+# HeavyDrops Transcoder v8.1.0 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v8.0.0 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v8.1.0 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v8.0.0
+title HeavyDrops Transcoder v8.1.0
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v8.0.0
+echo   HeavyDrops Transcoder v8.1.0
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v8.0.0"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v8.1.0"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v8.0.0" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v8.1.0" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v8.0.0"
+$Shortcut.Description = "HeavyDrops Transcoder v8.1.0"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "8.0.0"
+version = "8.1.0"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/database.py
+++ b/src/transcoder/database.py
@@ -93,6 +93,11 @@ class Job:
     # Lets the dispatcher route into the right worker pool without competing for
     # the same encoder.
     kind: str = "video"
+    # When the job last CHANGED state — unlike updated_at, this is immune to
+    # the jobs_updated_at trigger and progress writes, so the watchdog can
+    # measure true time-in-state. None on rows read mid-migration; callers
+    # fall back to updated_at.
+    state_changed_at: datetime | None = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> Job:
@@ -104,6 +109,10 @@ class Job:
             kind = row['kind'] or "video"
         except (IndexError, KeyError):
             kind = "video"
+        try:
+            state_changed_at = _parse_datetime(row['state_changed_at'])
+        except (IndexError, KeyError):
+            state_changed_at = None
         return cls(
             id=row['id'],
             dropbox_path=row['dropbox_path'],
@@ -126,6 +135,8 @@ class Job:
             transcode_end=_parse_datetime(row['transcode_end']),
             created_at=_parse_datetime(row['created_at']) or datetime.now(timezone.utc),
             updated_at=_parse_datetime(row['updated_at']) or datetime.now(timezone.utc),
+            kind=kind,
+            state_changed_at=state_changed_at,
         )
 
 
@@ -203,6 +214,13 @@ CREATE TABLE IF NOT EXISTS jobs (
     kind TEXT NOT NULL DEFAULT 'video',
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    -- Timeout clock for the watchdog. The jobs_updated_at trigger refreshes
+    -- updated_at on EVERY row update (progress writes, retry bumps, ...), so
+    -- updated_at cannot measure how long a job has sat in its current state —
+    -- a near-frozen transcode that trickles row updates resets it forever
+    -- (the 6-day zombie of v7.9). state_changed_at is written ONLY by state
+    -- transitions (update_job_state / recover / reset) and nothing else.
+    state_changed_at TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE(dropbox_path, dropbox_rev)
 );
 
@@ -393,6 +411,17 @@ class Database:
             # Older DBs predate the audio pipeline. Backfill 'video' for every
             # existing row so dispatcher routing is unambiguous.
             conn.execute("ALTER TABLE jobs ADD COLUMN kind TEXT NOT NULL DEFAULT 'video'")
+        if 'state_changed_at' not in existing:
+            # Watchdog timeout clock (see SCHEMA comment). ADD COLUMN can't
+            # take a non-constant default in SQLite, so add then backfill from
+            # updated_at — the closest available approximation for old rows.
+            # (The backfill UPDATE fires the jobs_updated_at trigger once,
+            # refreshing updated_at across existing rows; cosmetic only.)
+            conn.execute("ALTER TABLE jobs ADD COLUMN state_changed_at TEXT")
+            conn.execute(
+                "UPDATE jobs SET state_changed_at = updated_at "
+                "WHERE state_changed_at IS NULL"
+            )
         # Refresh idx_jobs_active_path so newer SKIPPED_* states (added in
         # later versions like SKIPPED_LOW_BITRATE) are treated as terminal
         # by the unique-active-path constraint. SQLite re-creates indexes
@@ -590,7 +619,10 @@ class Database:
         Returns:
             True if job was updated.
         """
-        fields = ['state = ?']
+        # Every call to this method is a state transition — stamp the
+        # watchdog's timeout clock. (Non-transition row updates — progress,
+        # retry bumps — go through other methods and leave this untouched.)
+        fields = ['state = ?', "state_changed_at = datetime('now')"]
         values: list[Any] = [state.value]
 
         if error_message is not None:
@@ -650,7 +682,8 @@ class Database:
         with self.transaction() as conn:
             placeholders = ','.join('?' * len(ACTIVE_STATES))
             cursor = conn.execute(
-                f"UPDATE jobs SET state = ? WHERE state IN ({placeholders})",
+                f"UPDATE jobs SET state = ?, state_changed_at = datetime('now') "
+                f"WHERE state IN ({placeholders})",
                 [JobState.RETRY_WAIT.value] + [s.value for s in ACTIVE_STATES],
             )
             return cursor.rowcount
@@ -669,7 +702,10 @@ class Database:
         """
         with self.transaction() as conn:
             params: list = [JobState.RETRY_WAIT.value, JobState.FAILED.value]
-            sql = "UPDATE jobs SET state = ?, retry_count = 0 WHERE state = ?"
+            sql = (
+                "UPDATE jobs SET state = ?, retry_count = 0, "
+                "state_changed_at = datetime('now') WHERE state = ?"
+            )
             if path_prefix:
                 prefix = path_prefix.rstrip('/')
                 sql += " AND (dropbox_path = ? OR dropbox_path LIKE ?)"

--- a/src/transcoder/dropbox_client.py
+++ b/src/transcoder/dropbox_client.py
@@ -212,6 +212,16 @@ class DropboxClient:
     # per-chunk retry cost modest on a flaky link while cutting round-trips.
     CHUNK_SIZE = 16 * 1024 * 1024  # 16MB chunks for upload
     DOWNLOAD_CHUNK_SIZE = 8 * 1024 * 1024  # 8MB chunks for download (stream read buffer)
+    # Each download is fetched as a sequence of bounded byte-range GETs rather
+    # than one long stream. Dropbox (and intervening firewalls/proxies) tend to
+    # drop a single download connection after ~10GB / a few minutes, surfacing
+    # as urllib3 IncompleteRead. Capping each request well under that ceiling
+    # means no single connection lives long enough to be cut, and any break that
+    # does happen is retried in-place from the bytes already on disk — no job
+    # failure, no watchdog backoff cycle. 2GB keeps the request count modest
+    # (~26 GETs for a 52GB file) while staying comfortably below the cliff.
+    DOWNLOAD_SEGMENT_SIZE = 2 * 1024 * 1024 * 1024  # 2GB per ranged request
+    DOWNLOAD_SEGMENT_MAX_RETRIES = 6  # consecutive broken-connection retries before giving up
 
     def __init__(
         self,
@@ -725,38 +735,78 @@ class DropboxClient:
                     f"({resume_offset / total_size * 100:.1f}%)"
                 )
 
-        # Temp link supports Range headers; SDK files_download does not.
-        link_result = self._retry_operation(
-            lambda: self._dbx.files_get_temporary_link(norm_path),
-            f"get_temporary_link({dropbox_path})",
-        )
-        url = link_result.link
-
-        headers = {}
-        if resume_offset > 0:
-            headers['Range'] = f'bytes={resume_offset}-'
-
-        resp = requests.get(url, headers=headers, stream=True, timeout=120)
-        if resume_offset > 0 and resp.status_code not in (200, 206):
-            logger.warning(
-                f"Server returned {resp.status_code} on resume attempt; "
-                f"restarting from zero"
+        # Temp link supports Range headers; SDK files_download does not. The
+        # link is valid for ~4h; refresh it on demand if the server starts
+        # rejecting it mid-download (401/403/410).
+        def _fresh_link() -> str:
+            link_result = self._retry_operation(
+                lambda: self._dbx.files_get_temporary_link(norm_path),
+                f"get_temporary_link({dropbox_path})",
             )
-            resume_offset = 0
-            resp.close()
-            resp = requests.get(url, stream=True, timeout=120)
-        if resp.status_code not in (200, 206):
-            resp.close()
-            raise DropboxClientError(
-                f"Download HTTP {resp.status_code} for {dropbox_path}"
-            )
+            return link_result.link
 
+        url = _fresh_link()
         bytes_downloaded = resume_offset
-        try:
-            mode = 'ab' if resume_offset > 0 else 'wb'
-            with open(local_path, mode) as f:
-                for chunk in resp.iter_content(chunk_size=self.DOWNLOAD_CHUNK_SIZE):
-                    if chunk:
+        mode = 'ab' if resume_offset > 0 else 'wb'
+
+        # Fetch the file as a sequence of bounded byte-range requests so no
+        # single connection lives long enough to hit the ~10GB drop ceiling.
+        # A connection that breaks mid-segment is retried from the bytes
+        # already flushed to disk, so progress is never lost and the job never
+        # fails out to the watchdog.
+        with open(local_path, mode) as f:
+            attempt = 0
+            while bytes_downloaded < total_size:
+                seg_start = bytes_downloaded
+                seg_end = min(seg_start + self.DOWNLOAD_SEGMENT_SIZE, total_size) - 1
+                headers = {'Range': f'bytes={seg_start}-{seg_end}'}
+
+                try:
+                    resp = requests.get(url, headers=headers, stream=True, timeout=120)
+                except requests.exceptions.RequestException as e:
+                    attempt += 1
+                    if attempt > self.DOWNLOAD_SEGMENT_MAX_RETRIES:
+                        raise DropboxClientError(
+                            f"Download failed for {dropbox_path} at "
+                            f"{bytes_downloaded / (1024**3):.1f}/"
+                            f"{total_size / (1024**3):.1f} GB: {e}"
+                        ) from e
+                    time.sleep(min(2 ** attempt, 30))
+                    continue
+
+                # Link expired / rejected: refresh and retry the same range.
+                if resp.status_code in (401, 403, 410):
+                    resp.close()
+                    attempt += 1
+                    if attempt > self.DOWNLOAD_SEGMENT_MAX_RETRIES:
+                        raise DropboxClientError(
+                            f"Download link kept being rejected ({resp.status_code}) "
+                            f"for {dropbox_path}"
+                        )
+                    url = _fresh_link()
+                    continue
+
+                # Server ignored Range and is streaming from byte 0. Only safe
+                # at the very start; mid-file it would corrupt the append.
+                if resp.status_code == 200:
+                    if seg_start == 0:
+                        seg_end = total_size - 1
+                    else:
+                        resp.close()
+                        raise DropboxClientError(
+                            f"Server ignored Range (HTTP 200) at offset "
+                            f"{seg_start} for {dropbox_path}"
+                        )
+                elif resp.status_code != 206:
+                    resp.close()
+                    raise DropboxClientError(
+                        f"Download HTTP {resp.status_code} for {dropbox_path}"
+                    )
+
+                try:
+                    for chunk in resp.iter_content(chunk_size=self.DOWNLOAD_CHUNK_SIZE):
+                        if not chunk:
+                            continue
                         f.write(chunk)
                         bytes_downloaded += len(chunk)
 
@@ -766,8 +816,7 @@ class DropboxClient:
 
                         # Periodic rev check (fast-fail on a mid-download
                         # overwrite). check_interval <= 0 disables it entirely;
-                        # the final rev/size checks after the loop still guard
-                        # correctness either way.
+                        # the final size check below still guards correctness.
                         if check_interval > 0 and \
                                 bytes_downloaded - last_check_bytes >= check_interval:
                             current_metadata = self._dbx.files_get_metadata(norm_path)
@@ -778,8 +827,34 @@ class DropboxClient:
                                         f"{bytes_downloaded / (1024*1024):.1f} MB"
                                     )
                             last_check_bytes = bytes_downloaded
-        finally:
-            resp.close()
+                except DropboxRevChangedError:
+                    resp.close()
+                    raise
+                except requests.exceptions.RequestException as e:
+                    # Connection dropped mid-segment (the IncompleteRead case).
+                    # Flush what we have and resume from the new on-disk offset.
+                    resp.close()
+                    f.flush()
+                    attempt += 1
+                    if attempt > self.DOWNLOAD_SEGMENT_MAX_RETRIES:
+                        raise DropboxClientError(
+                            f"Download stalled for {dropbox_path} after {attempt} "
+                            f"reconnects at {bytes_downloaded / (1024**3):.1f}/"
+                            f"{total_size / (1024**3):.1f} GB: {e}"
+                        ) from e
+                    logger.info(
+                        f"Download connection broke at "
+                        f"{bytes_downloaded / (1024**3):.1f}/"
+                        f"{total_size / (1024**3):.1f} GB for {dropbox_path}; "
+                        f"reconnecting (attempt {attempt})"
+                    )
+                    time.sleep(min(2 ** attempt, 15))
+                    continue
+                else:
+                    # Segment streamed cleanly — reset the retry budget so the
+                    # cap only ever counts *consecutive* failures.
+                    resp.close()
+                    attempt = 0
 
         if bytes_downloaded < total_size:
             raise DropboxClientError(

--- a/src/transcoder/main.py
+++ b/src/transcoder/main.py
@@ -537,8 +537,17 @@ class Daemon:
             worker.start()
             self.workers.append(worker)
 
-        # Watchdog
-        watchdog = Watchdog(self.config, self.db, self.stop_event)
+        # Watchdog. Gets the pipeline workers so a stage timeout kills the
+        # offending job's in-flight process (ffmpeg / download stream) instead
+        # of flipping DB state under a still-running zombie, and the disk
+        # budget so orphaned timeouts release their staging reservation.
+        watchdog = Watchdog(
+            self.config,
+            self.db,
+            self.stop_event,
+            workers=list(self.workers),
+            disk_budget=self.disk_budget,
+        )
         watchdog.start()
         self.workers.append(watchdog)
 

--- a/src/transcoder/watchdog.py
+++ b/src/transcoder/watchdog.py
@@ -36,6 +36,8 @@ class Watchdog(threading.Thread):
         db: Database,
         stop_event: threading.Event,
         check_interval: int = 60,
+        workers: list | None = None,
+        disk_budget=None,
     ):
         """
         Initialize watchdog.
@@ -45,12 +47,24 @@ class Watchdog(threading.Thread):
             db: Database instance.
             stop_event: Event to signal shutdown.
             check_interval: Seconds between checks.
+            workers: Pipeline workers (anything exposing abort_job). On a
+                timeout the watchdog first kills the offending job's in-flight
+                process through its worker, so the stuck thread unblocks and
+                runs its own cleanup, instead of just flipping DB state under
+                a still-running ffmpeg.
+            disk_budget: DiskBudget, so orphaned timeouts release their
+                staging reservation instead of deadlocking the budget.
         """
         super().__init__(name="watchdog", daemon=True)
         self.config = config
         self.db = db
         self.stop_event = stop_event
         self.check_interval = check_interval
+        self.workers = workers if workers is not None else []
+        self.disk_budget = disk_budget
+        # job_id -> soft-kill attempts. After 2 ticks where the kill didn't
+        # unstick the worker, the watchdog takes over the DB transition itself.
+        self._kill_attempts: dict[int, int] = {}
         # Failed-revive cooldown: when the download pipeline goes idle we
         # promote every FAILED job back to RETRY_WAIT to give it another
         # shot. Cooldown prevents thrashing if the same jobs immediately
@@ -69,6 +83,7 @@ class Watchdog(threading.Thread):
                 self._check_timeouts()
                 self._check_retry_ready()
                 self._check_failed_revive()
+                self._check_stale_reservations()
             except Exception as e:
                 logger.error(f"Watchdog error: {e}")
 
@@ -83,24 +98,46 @@ class Watchdog(threading.Thread):
     def _check_timeouts(self) -> None:
         """Check for jobs that have exceeded timeout."""
         now = datetime.now(timezone.utc)
+        active_ids: set[int] = set()
 
         # Check downloading jobs
         for job in self.db.get_jobs_by_state(JobState.DOWNLOADING, limit=100):
+            active_ids.add(job.id)
             if self._is_job_timed_out(job, self.config.watchdog.download_timeout_sec, now):
                 logger.warning(f"Job {job.id} download timeout, requeueing")
                 self._handle_timeout(job, "Download timeout")
 
         # Check transcoding jobs
         for job in self.db.get_jobs_by_state(JobState.TRANSCODING, limit=100):
+            active_ids.add(job.id)
             if self._is_job_timed_out(job, self.config.watchdog.transcode_timeout_sec, now):
                 logger.warning(f"Job {job.id} transcode timeout, requeueing")
                 self._handle_timeout(job, "Transcode timeout")
 
         # Check uploading jobs
         for job in self.db.get_jobs_by_state(JobState.UPLOADING, limit=100):
+            active_ids.add(job.id)
             if self._is_job_timed_out(job, self.config.watchdog.upload_timeout_sec, now):
                 logger.warning(f"Job {job.id} upload timeout, requeueing")
                 self._handle_timeout(job, "Upload timeout")
+
+        # Kill-attempt counters for jobs that left the active states (the
+        # worker's cleanup ran, or an operator intervened) are done with.
+        self._kill_attempts = {
+            jid: n for jid, n in self._kill_attempts.items() if jid in active_ids
+        }
+
+    @staticmethod
+    def _state_clock(job: Job) -> datetime | None:
+        """Timestamp the job entered its current state.
+
+        Prefer state_changed_at: updated_at is refreshed by the
+        jobs_updated_at trigger on EVERY row update (progress, retry bumps),
+        so a near-frozen ffmpeg that trickles updates resets updated_at
+        forever and its job never times out (the 6-day zombie transcode).
+        Fall back to updated_at only for rows read mid-migration.
+        """
+        return job.state_changed_at or job.updated_at
 
     def _is_job_timed_out(
         self,
@@ -109,15 +146,32 @@ class Watchdog(threading.Thread):
         now: datetime,
     ) -> bool:
         """Check if job has exceeded timeout."""
-        # Use updated_at as the state entry time
-        if not job.updated_at:
+        entered = self._state_clock(job)
+        if not entered:
             return False
 
-        elapsed = (now - job.updated_at).total_seconds()
+        elapsed = (now - entered).total_seconds()
         return elapsed > timeout_sec
 
     def _handle_timeout(self, job: Job, reason: str) -> None:
-        """Handle a timed-out job."""
+        """Handle a timed-out job.
+
+        First try to kill the in-flight process (ffmpeg / download stream)
+        through the worker that owns the job. The kill unblocks the stuck
+        worker thread, whose own failure path then runs the full cleanup —
+        retry increment, RETRY_WAIT/FAILED, disk-budget release, staging rm —
+        with no state race against the watchdog.
+
+        Only when no worker owns the job (orphaned state after a crash), or
+        the kill failed to unstick it after 2 ticks, does the watchdog take
+        over: flip the DB state and reclaim the staging reservation itself.
+        """
+        attempts = self._kill_attempts.get(job.id, 0)
+        if attempts < 2 and self._abort_in_flight(job, reason):
+            self._kill_attempts[job.id] = attempts + 1
+            return
+
+        self._kill_attempts.pop(job.id, None)
         retry_count, should_fail = self.db.increment_retry(
             job.id,
             self.config.watchdog.max_retries,
@@ -137,6 +191,51 @@ class Watchdog(threading.Thread):
                 error_message=f"{reason} (retry {retry_count})",
             )
 
+        # The owning worker is gone (or hopelessly stuck) — nobody else will
+        # ever release this job's staging reservation. Reclaim it here or the
+        # budget stays exhausted and every downloader stalls forever.
+        if self.disk_budget is not None:
+            self.disk_budget.release(job.id)
+
+    def _abort_in_flight(self, job: Job, reason: str) -> bool:
+        """Ask each pipeline worker to kill its in-flight process for `job`.
+
+        Returns True when a worker owned the job AND actually delivered a
+        kill (ffmpeg terminated / download stream aborted).
+        """
+        for worker in self.workers:
+            abort = getattr(worker, "abort_job", None)
+            if abort is None:
+                continue
+            try:
+                if abort(job.id, reason):
+                    return True
+            except Exception:
+                logger.exception(
+                    "abort_job(%s) failed on worker %s", job.id, worker
+                )
+        return False
+
+    def _check_stale_reservations(self) -> None:
+        """Reclaim disk reservations whose jobs are no longer active.
+
+        Startup already prunes these, but a daemon that runs for weeks needs
+        the same self-healing continuously: one leaked reservation (worker
+        crash, kill -9, code bug) otherwise pins the budget until the next
+        restart — the 3-day 'staging budget exhausted' deadlock of v7.9.
+        """
+        try:
+            pruned = self.db.prune_stale_disk_reservations(ACTIVE_STATES)
+        except Exception:
+            logger.exception("prune_stale_disk_reservations failed")
+            return
+        if pruned:
+            logger.warning(
+                "watchdog: reclaimed %d stale disk reservation(s) held by "
+                "non-active jobs — staging budget was leaking",
+                pruned,
+            )
+
     def _check_retry_ready(self) -> None:
         """Check for RETRY_WAIT jobs ready to be retried."""
         now = datetime.now(timezone.utc)
@@ -145,8 +244,9 @@ class Watchdog(threading.Thread):
             # Calculate backoff delay
             delay = min(300, 5 * (2 ** job.retry_count))
 
-            if job.updated_at:
-                elapsed = (now - job.updated_at).total_seconds()
+            entered = self._state_clock(job)
+            if entered:
+                elapsed = (now - entered).total_seconds()
                 if elapsed >= delay:
                     logger.info(f"Job {job.id} ready for retry after {elapsed:.0f}s backoff")
                     self.db.update_job_state(job.id, JobState.NEW)

--- a/src/transcoder/workers.py
+++ b/src/transcoder/workers.py
@@ -133,6 +133,33 @@ class BaseWorker(threading.Thread):
         """Check if worker should stop."""
         return self.stop_event.is_set()
 
+    def abort_job(self, job_id: int, reason: str = "") -> bool:
+        """Kill this worker's in-flight process if it is working `job_id`.
+
+        Called by the watchdog (from its own thread) when the job exceeds its
+        stage timeout. Killing the process unblocks this worker's thread, so
+        its normal failure path runs the cleanup — retry increment, state
+        flip, disk-budget release — exactly as if the process had died on its
+        own. Returns True only when a kill was actually delivered; False when
+        this worker doesn't own the job or has nothing killable (the watchdog
+        then handles the job in the DB itself).
+        """
+        job = self._current_job
+        if job is None or job.id != job_id:
+            return False
+        if not self._abort_current():
+            return False
+        logger.warning(
+            f"[{self.name}] watchdog killed in-flight work for job {job_id}: "
+            f"{reason}"
+        )
+        return True
+
+    def _abort_current(self) -> bool:
+        """Subclass hook: kill whatever process/stream the worker is blocked
+        on right now. Return True if a kill was delivered."""
+        return False
+
 
 class DownloadWorker(BaseWorker):
     """Worker that downloads files from Dropbox."""
@@ -156,9 +183,18 @@ class DownloadWorker(BaseWorker):
         self.scanner = scanner
         self.disk_budget = disk_budget
         self.claims = claims
+        # Set by the watchdog (via abort_job) to break out of an in-flight
+        # transfer; checked in the download progress callback. Cleared at the
+        # start of every job so one abort never bleeds into the next.
+        self._abort_download = threading.Event()
+
+    def _abort_current(self) -> bool:
+        self._abort_download.set()
+        return True
 
     def process_job(self, job: Job) -> None:
         """Download the file for the given job."""
+        self._abort_download.clear()
         # Defensive: even though scanner skips /assets/ paths since v6.2.2,
         # jobs created BEFORE that update may still be sitting in the DB
         # in NEW state. Catch them here BEFORE wasting bandwidth on the
@@ -547,6 +583,14 @@ class DownloadWorker(BaseWorker):
         def callback(downloaded: int, total: int) -> None:
             if self.should_stop():
                 raise WorkerStop("Worker stopping")
+            # Watchdog decided this download exceeded its timeout. Raising
+            # here lands in the generic failure path: retry increment,
+            # RETRY_WAIT, reservation released; the partial is kept on disk
+            # so the retry resumes instead of restarting.
+            if self._abort_download.is_set():
+                raise RuntimeError(
+                    "download aborted by watchdog (stage timeout exceeded)"
+                )
             # Night mode (or a manual pause) — stop downloading too, not just
             # transcoding. The partial is kept, so it resumes next window.
             if self.dispatcher.is_paused():
@@ -1228,6 +1272,16 @@ class TranscodeWorker(BaseWorker):
             except Exception as e:
                 logger.warning(f"Error killing FFmpeg: {e}")
 
+    def _abort_current(self) -> bool:
+        """Watchdog kill hook: terminate the in-flight ffmpeg. The blocked
+        _run_ffmpeg wait sees the process exit, the job takes the normal
+        failure path (retry increment, RETRY_WAIT/FAILED, disk release)."""
+        proc = self._ffmpeg_process
+        if proc is None or proc.poll() is not None:
+            return False
+        self._kill_ffmpeg()
+        return True
+
     def _cleanup_staging(self, job: Job) -> None:
         """Clean up staging directory for job."""
         if job.local_input_path:
@@ -1342,6 +1396,21 @@ class AudioTranscoder(BaseWorker):
     ):
         super().__init__(f"audio-{worker_id}", config, db, stop_event, dispatcher)
         self._ffmpeg_process: subprocess.Popen | None = None
+
+    def _abort_current(self) -> bool:
+        """Watchdog kill hook — same semantics as TranscodeWorker's."""
+        proc = self._ffmpeg_process
+        if proc is None or proc.poll() is not None:
+            return False
+        try:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        except Exception as e:
+            logger.warning(f"[{self.name}] Error killing FFmpeg: {e}")
+        return True
 
     def process_job(self, job: Job) -> None:
         logger.info(f"[{self.name}] Audio transcoding: {job.dropbox_path}")

--- a/tests/test_download_resume.py
+++ b/tests/test_download_resume.py
@@ -63,8 +63,10 @@ class TestResumeFromPartial:
 
         assert rev == "r1"
         assert dest.read_bytes() == b"x" * 32
+        # Downloads are now fetched as bounded byte ranges; a fresh download
+        # still starts at byte 0, capped at the file's last byte.
         call_args = mock_get.call_args
-        assert 'Range' not in call_args.kwargs.get('headers', {})
+        assert call_args.kwargs['headers']['Range'] == 'bytes=0-31'
 
     def test_resume_sends_range_header(self, tmp_path):
         client = _make_client()
@@ -91,7 +93,9 @@ class TestResumeFromPartial:
                 )
 
         call_args = mock_get.call_args
-        assert call_args.kwargs['headers']['Range'] == 'bytes=100-'
+        # Resume now requests a bounded range (start to the file's last byte)
+        # instead of an open-ended bytes=100- stream.
+        assert call_args.kwargs['headers']['Range'] == 'bytes=100-199'
         content = dest.read_bytes()
         assert content == b"A" * 100 + b"B" * 100
 
@@ -110,6 +114,56 @@ class TestResumeFromPartial:
 
         assert rev == "r1"
         client._dbx.files_get_temporary_link.assert_not_called()
+
+
+class TestSegmentedReconnect:
+    """A connection dropped mid-download (IncompleteRead) is retried in-place."""
+
+    def test_reconnects_after_broken_connection(self, tmp_path):
+        import requests as _requests
+        client = _make_client()
+        dest = tmp_path / "video.mp4.partial"
+        total = 50
+
+        md = _fake_metadata(rev="r1", size=total)
+        client._dbx.files_get_metadata.return_value = md
+
+        link_result = MagicMock()
+        link_result.link = "https://cdn.example.com/file"
+        client._dbx.files_get_temporary_link.return_value = link_result
+
+        # First GET writes 20 bytes, then the connection breaks like Dropbox's
+        # ~10GB IncompleteRead (surfaced by requests as ChunkedEncodingError).
+        resp1 = MagicMock()
+        resp1.status_code = 206
+        resp1.close = MagicMock()
+
+        def _iter_then_break(chunk_size):
+            yield b"A" * 20
+            raise _requests.exceptions.ChunkedEncodingError(
+                "Connection broken: IncompleteRead(20 bytes read, 30 more expected)"
+            )
+
+        resp1.iter_content.side_effect = _iter_then_break
+
+        # Second GET resumes from byte 20 and finishes the file cleanly.
+        resp2 = MagicMock()
+        resp2.status_code = 206
+        resp2.iter_content.return_value = [b"B" * 30]
+        resp2.close = MagicMock()
+
+        with patch("requests.get", side_effect=[resp1, resp2]) as mock_get:
+            with patch("transcoder.dropbox_client.FileMetadata", type(md)):
+                with patch("time.sleep"):
+                    rev = client.download_file_with_rev_check(
+                        "/test.mp4", dest, expected_rev="r1"
+                    )
+
+        assert rev == "r1"
+        # No bytes lost across the break, no duplication.
+        assert dest.read_bytes() == b"A" * 20 + b"B" * 30
+        # The retry resumed from exactly where the connection died.
+        assert mock_get.call_args_list[1].kwargs['headers']['Range'] == 'bytes=20-49'
 
 
 class TestRevCheckDuringResume:

--- a/tests/test_proxies_skip.py
+++ b/tests/test_proxies_skip.py
@@ -87,6 +87,7 @@ def test_download_worker_skips_loose_proxy_filename():
     worker = object.__new__(DownloadWorker)
     threading.Thread.__init__(worker, name="downloader-test", daemon=True)
     worker.db = _FakeDB()
+    worker._abort_download = threading.Event()
 
     # _Proxy file NOT inside a proxy folder — must still be skipped.
     job = SimpleNamespace(
@@ -161,6 +162,7 @@ def test_download_worker_skips_queued_proxy_job():
     # Workers are Thread subclasses; the name property needs Thread.__init__.
     threading.Thread.__init__(worker, name="downloader-test", daemon=True)
     worker.db = _FakeDB()
+    worker._abort_download = threading.Event()
 
     job = SimpleNamespace(
         id=1553,

--- a/tests/test_watchdog_kill.py
+++ b/tests/test_watchdog_kill.py
@@ -1,0 +1,211 @@
+"""Tests for watchdog kill-on-timeout, the state_changed_at timeout clock,
+and continuous disk-reservation reconciliation.
+
+Regression suite for the v7.9 HEAVY7 incident: two ffmpeg processes ran for
+6+ days (a near-frozen transcode trickled row updates, and the trigger-
+refreshed updated_at meant the timeout never fired), their jobs pinned the
+entire 1.82TB staging budget, and every downloader stalled on
+"staging budget exhausted" for 3 days straight.
+"""
+import sys
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from transcoder.database import ACTIVE_STATES, Database, Job, JobState  # noqa: E402
+from transcoder.watchdog import Watchdog  # noqa: E402
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = Database(tmp_path / "test.db")
+    d.initialize()
+    yield d
+    d.close()
+
+
+def _add_job(db: Database, state: JobState, path: str = "/videos/a.mp4") -> int:
+    job = db.create_job(
+        dropbox_path=path,
+        dropbox_rev="rev1",
+        dropbox_size=1000,
+        output_path=path.rsplit("/", 1)[0] + "/h265/" + path.rsplit("/", 1)[1],
+    )
+    db.update_job_state(job.id, state)
+    return job.id
+
+
+def _get_job(db: Database, job_id: int) -> Job:
+    conn = db._get_connection()
+    row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+    return Job.from_row(row)
+
+
+def _backdate_state_change(db: Database, job_id: int, hours: float) -> None:
+    """Move state_changed_at into the past without touching state."""
+    conn = db._get_connection()
+    past = (datetime.now(timezone.utc) - timedelta(hours=hours)).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    conn.execute(
+        "UPDATE jobs SET state_changed_at = ? WHERE id = ?", (past, job_id)
+    )
+    conn.commit()
+
+
+def _make_watchdog(db: Database, workers=None, disk_budget=None) -> Watchdog:
+    config = MagicMock()
+    config.watchdog.download_timeout_sec = 7200
+    config.watchdog.transcode_timeout_sec = 86400
+    config.watchdog.upload_timeout_sec = 7200
+    config.watchdog.max_retries = 10
+    config.watchdog.failed_revive_cooldown_sec = 600.0
+    return Watchdog(
+        config, db, threading.Event(),
+        workers=workers or [], disk_budget=disk_budget,
+    )
+
+
+class TestStateChangedAtClock:
+    """state_changed_at moves only on state transitions."""
+
+    def test_stamped_on_state_transition(self, db):
+        job_id = _add_job(db, JobState.TRANSCODING)
+        job = _get_job(db, job_id)
+        assert job.state_changed_at is not None
+        age = (datetime.now(timezone.utc) - job.state_changed_at).total_seconds()
+        assert age < 60
+
+    def test_not_refreshed_by_non_state_row_updates(self, db):
+        """The jobs_updated_at trigger refreshes updated_at on ANY row update;
+        state_changed_at must survive that (this is the 6-day-zombie bug)."""
+        job_id = _add_job(db, JobState.TRANSCODING)
+        _backdate_state_change(db, job_id, hours=48)
+
+        # A non-transition row update — e.g. a retry bump — fires the trigger.
+        time.sleep(1.1)  # datetime('now') has 1s resolution
+        db.increment_retry(job_id, max_retries=10)
+
+        job = _get_job(db, job_id)
+        # updated_at got refreshed by the trigger…
+        assert (datetime.now(timezone.utc) - job.updated_at).total_seconds() < 60
+        # …but the timeout clock did not move.
+        age_h = (
+            datetime.now(timezone.utc) - job.state_changed_at
+        ).total_seconds() / 3600
+        assert age_h > 47
+
+    def test_zombie_times_out_despite_fresh_updated_at(self, db):
+        """A transcode 48h in-state whose row was just touched must time out."""
+        job_id = _add_job(db, JobState.TRANSCODING)
+        _backdate_state_change(db, job_id, hours=48)
+        db.increment_retry(job_id, max_retries=10)  # refreshes updated_at
+
+        wd = _make_watchdog(db)
+        job = _get_job(db, job_id)
+        assert wd._is_job_timed_out(job, 86400, datetime.now(timezone.utc))
+
+    def test_recover_active_jobs_restamps_clock(self, db):
+        job_id = _add_job(db, JobState.TRANSCODING)
+        _backdate_state_change(db, job_id, hours=48)
+        db.recover_active_jobs()
+        job = _get_job(db, job_id)
+        assert job.state == JobState.RETRY_WAIT
+        age = (datetime.now(timezone.utc) - job.state_changed_at).total_seconds()
+        assert age < 60
+
+
+class TestKillOnTimeout:
+    """Timeout kills the in-flight process through the owning worker."""
+
+    def test_worker_kill_claims_job_and_watchdog_stays_out_of_db(self, db):
+        job_id = _add_job(db, JobState.TRANSCODING)
+        _backdate_state_change(db, job_id, hours=48)
+        job = _get_job(db, job_id)
+
+        worker = MagicMock()
+        worker.abort_job.return_value = True
+        wd = _make_watchdog(db, workers=[worker])
+
+        wd._handle_timeout(job, "Transcode timeout")
+
+        worker.abort_job.assert_called_once()
+        # State untouched — the killed worker's own failure path owns cleanup.
+        assert _get_job(db, job_id).state == JobState.TRANSCODING
+        assert _get_job(db, job_id).retry_count == 0
+
+    def test_orphan_job_is_requeued_and_reservation_released(self, db):
+        """No worker owns the job: watchdog flips state AND frees the budget."""
+        job_id = _add_job(db, JobState.TRANSCODING)
+        _backdate_state_change(db, job_id, hours=48)
+        db.reserve_disk(job_id, 10_000_000_000)
+        job = _get_job(db, job_id)
+
+        budget = MagicMock()
+        wd = _make_watchdog(db, workers=[], disk_budget=budget)
+
+        wd._handle_timeout(job, "Transcode timeout")
+
+        assert _get_job(db, job_id).state == JobState.RETRY_WAIT
+        assert _get_job(db, job_id).retry_count == 1
+        budget.release.assert_called_once_with(job_id)
+
+    def test_stuck_worker_falls_through_after_two_kill_attempts(self, db):
+        """abort_job returns True but never unsticks — attempt 3 takes over."""
+        job_id = _add_job(db, JobState.TRANSCODING)
+        _backdate_state_change(db, job_id, hours=48)
+        job = _get_job(db, job_id)
+
+        worker = MagicMock()
+        worker.abort_job.return_value = True
+        budget = MagicMock()
+        wd = _make_watchdog(db, workers=[worker], disk_budget=budget)
+
+        wd._handle_timeout(job, "Transcode timeout")  # kill attempt 1
+        wd._handle_timeout(job, "Transcode timeout")  # kill attempt 2
+        assert _get_job(db, job_id).state == JobState.TRANSCODING
+
+        wd._handle_timeout(job, "Transcode timeout")  # watchdog takes over
+        assert _get_job(db, job_id).state == JobState.RETRY_WAIT
+        budget.release.assert_called_once_with(job_id)
+
+    def test_workers_without_abort_hook_are_skipped(self, db):
+        job_id = _add_job(db, JobState.UPLOADING)
+        _backdate_state_change(db, job_id, hours=48)
+        job = _get_job(db, job_id)
+
+        not_a_worker = object()  # e.g. the Watchdog itself in main.workers
+        wd = _make_watchdog(db, workers=[not_a_worker])
+
+        wd._handle_timeout(job, "Upload timeout")
+        assert _get_job(db, job_id).state == JobState.RETRY_WAIT
+
+
+class TestStaleReservationReconcile:
+    """Leaked reservations are reclaimed continuously, not just at startup."""
+
+    def test_reservation_of_terminal_job_is_pruned(self, db):
+        done_id = _add_job(db, JobState.DONE, path="/videos/done.mp4")
+        active_id = _add_job(db, JobState.DOWNLOADING, path="/videos/dl.mp4")
+        db.reserve_disk(done_id, 5_000_000_000)
+        db.reserve_disk(active_id, 7_000_000_000)
+        assert db.total_reserved_bytes() == 12_000_000_000
+
+        wd = _make_watchdog(db)
+        wd._check_stale_reservations()
+
+        # DONE job's leak reclaimed; the active job's reservation survives.
+        assert db.total_reserved_bytes() == 7_000_000_000
+
+    def test_noop_when_nothing_leaked(self, db):
+        active_id = _add_job(db, JobState.TRANSCODING)
+        db.reserve_disk(active_id, 1_000)
+        wd = _make_watchdog(db)
+        wd._check_stale_reservations()
+        assert db.total_reserved_bytes() == 1_000

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v8.0.0
+HeavyDrops Transcoder v8.1.0
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "8.0.0"
+VERSION = "8.1.0"
 
 import socket
 import subprocess


### PR DESCRIPTION
## Problems fixed (both observed on HEAVY7)

### 1. Downloads dying at ~10 GB (`IncompleteRead`)
Single long-lived download streams were consistently cut around ~9.5–10.5 GB. Each break failed the whole job and burned a 10–60s watchdog backoff cycle; a 52 GB file needed 5+ retry rounds.

**Fix:** fetch every file as a sequence of bounded 2 GB byte-range requests. No connection lives long enough to hit the cliff, and a mid-segment break reconnects in place from the exact byte on disk without failing the job.

### 2. 6-day zombie transcodes + 3-day staging-budget deadlock
Two ffmpeg processes ran 6+ days without ever hitting the 24h transcode timeout; their jobs (plus 7 more in-flight) pinned the entire 1.82 TB staging budget, and every downloader sat on `staging budget exhausted` for 3 days doing **zero** work.

**Root cause:** the watchdog measured timeouts from `updated_at`, but the `jobs_updated_at` trigger refreshes `updated_at` on *every* jobs-row update — a near-frozen transcode that trickles row writes resets its own timeout clock forever.

**Fixes:**
- **`jobs.state_changed_at`** — written only on state transitions, with an idempotent `ALTER TABLE` migration backfilled from `updated_at`. Watchdog timeout + retry-backoff clocks now read it.
- **Kill on timeout** — the watchdog asks the owning worker to kill its in-flight process (`abort_job()`): TranscodeWorker/AudioTranscoder terminate their ffmpeg; DownloadWorker aborts its stream via an event checked in the progress callback. The unblocked worker's own failure path then runs the full cleanup (retry increment, state flip, disk-budget release, staging rm) with no state race. Orphaned jobs — or a kill that doesn't unstick the worker after 2 ticks — fall back to the watchdog flipping state itself, now also releasing the job's disk reservation.
- **Continuous budget reconcile** — `disk_reservations` is pruned on every watchdog tick (60s), not just at startup, so a leaked reservation self-heals instead of deadlocking the budget until the next restart.
- **Bonus:** `Job.from_row` dropped the `kind` column, so every job materialized as `"video"` and the dispatcher's kind filter never fed the audio (WAV→MP3) queue. Audio routes correctly again.

## Version
8.0.0 → **8.1.0** via `sync_version.py` (pyproject, `__init__`, GUI, installers) + release-notes entry in `NOTAS_DA_VERSAO.txt`.

## Tests
- New `tests/test_watchdog_kill.py` (10 tests): clock survives trigger/progress writes, zombie times out despite fresh `updated_at`, worker-owned kill leaves DB alone, orphan requeue releases reservation, 2-attempt fall-through, stale-reservation prune.
- Updated download-resume tests to the bounded-range protocol + mid-segment reconnect test.
- Full suite: **146 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bbMXYJJjbgyBkgA8dJJ8a