### PR TITLE
v8.2.0: auto-update — mergear no main atualiza toda máquina sozinha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,24 @@
 name: Publish Release
 
-# Publica uma GitHub Release para uma versão do HeavyDrops Transcoder.
+# Publica uma GitHub Release para a versão atual do HeavyDrops Transcoder.
 # O updater do daemon consulta /releases/latest e compara a tag com a
 # versão instalada — sem release publicada ele loga HTTP 404 a cada checagem.
 #
-# Dois gatilhos:
+# Gatilhos:
+#   - push no main: lê a versão do pyproject.toml e, se a release
+#     v<versão> ainda não existe, cria a tag e publica. Merges que não
+#     mudam a versão terminam sem fazer nada — toda release nova sai
+#     sozinha no merge que subir a versão.
+#   - push de tag v*: publica a release para a tag empurrada.
 #   - workflow_dispatch: informe a tag (ex.: v8.1.0); a tag é criada no
 #     commit atual do branch escolhido se ainda não existir.
-#   - push de tag v*: publica a release para a tag empurrada.
 #
 # As notas vêm da seção correspondente do NOTAS_DA_VERSAO.txt; se a seção
 # não existir, cai para as notas geradas automaticamente pelo GitHub.
 
 on:
   push:
+    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
     inputs:
@@ -30,9 +35,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag || '' }}
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          elif [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          else
+            VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+            TAG="v${VERSION}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Tag da release: $TAG"
+
       - name: Extract release notes from NOTAS_DA_VERSAO.txt
         env:
-          TAG: ${{ inputs.tag || github.ref_name }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           python3 - "${TAG#v}" <<'EOF'
           import re
@@ -57,7 +78,7 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag || github.ref_name }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "Release $TAG já existe; nada a fazer."

--- a/NOTAS_DA_VERSAO.txt
+++ b/NOTAS_DA_VERSAO.txt
@@ -2,6 +2,39 @@
                     HEAVYDROPS TRANSCODER - NOTAS DA VERSÃO
 ================================================================================
 
+Versão: 8.2.0
+Data: 15/07/2026
+--------------------------------------------------------------------------------
+
+Auto-update: mergear no main atualiza TODA máquina sozinha
+
+  [FEATURE] O updater deixou de ser só aviso. Agora ele checa as releases do
+        GitHub a cada 30 minutos (configurável) e, quando sai versão nova,
+        aplica sozinho: git pull + pip install (só quando o manifest mudou)
+        e reinicia o daemon pra carregar o código novo. O restart é limpo —
+        os jobs em voo são requeuados no boot e os downloads já feitos são
+        reaproveitados (mesma recuperação comprovada na subida da 8.1.0).
+  [FEATURE] Restart automático via Task Scheduler: um helper destacado
+        espera o processo antigo morrer e roda schtasks /Run na task
+        HeavyDropsDaemon; o exit code dedicado (42) faz o RestartOnFailure
+        da task servir de plano B se o helper falhar. Nada de comando
+        manual em nenhuma máquina.
+  [FEATURE] Publicação de release também ficou automática (workflow do
+        Actions): todo merge no main lê a versão do pyproject.toml e, se a
+        release v<versão> ainda não existe, cria a tag e publica com as
+        notas desta seção. Ou seja: mergear um bump de versão no main =
+        release publicada = todas as máquinas atualizadas em até ~30 min.
+  [CONFIG] updater.auto_apply (padrão true) desliga o modo automático se
+        quiser voltar ao aviso-no-dashboard + `hd update` manual;
+        updater.check_interval_sec ajusta a cadência da checagem;
+        updater.windows_task_name muda o nome da task usada no restart.
+  [GUARD] Sem loop de update: release cujo apply falhou (ou que não
+        avançou a versão do checkout) fica marcada e não é tentada de novo
+        até sair uma release mais nova; instalação que não é checkout git
+        nunca tenta aplicar (só avisa).
+
+--------------------------------------------------------------------------------
+
 Versão: 8.1.0
 Data: 14/07/2026
 --------------------------------------------------------------------------------

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -102,10 +102,19 @@ api:
   enabled: true
   bind: 127.0.0.1
   port: 9123
+# Auto-update: the daemon checks GitHub Releases every check_interval_sec.
+# With auto_apply on, a newer release is pulled in place (git + pip when the
+# manifest changed) and the daemon restarts itself via the Windows scheduled
+# task — merging to main is all it takes to update every machine. Set
+# auto_apply: false for the old notify-only behavior (dashboard badge +
+# manual `hd update`).
 updater:
   enabled: true
   github_repo: luisimperator/rep01
   check_timeout_sec: 5.0
+  check_interval_sec: 1800
+  auto_apply: true
+  windows_task_name: HeavyDropsDaemon
 # Remote health telemetry: publish a status snapshot (recent log tail, job
 # counts, disk free, any new crash.log) to GitHub on a timer so the daemon can
 # be watched without copying logs by hand. Off by default. github_token is

--- a/installer/HeavyDrops_Setup.iss
+++ b/installer/HeavyDrops_Setup.iss
@@ -2,7 +2,7 @@
 ; Creates a professional Windows installer with wizard interface
 
 #define MyAppName "HeavyDrops Transcoder"
-#define MyAppVersion "8.1.0"
+#define MyAppVersion "8.2.0"
 #define MyAppPublisher "HeavyDrops"
 #define MyAppURL "https://github.com/luisimperator/rep01"
 #define MyAppExeName "HeavyDrops_Transcoder.exe"

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,11 +1,11 @@
-# HeavyDrops Transcoder v8.1.0 Installer
+# HeavyDrops Transcoder v8.2.0 Installer
 # Run as Administrator: Right-click -> Run with PowerShell
 
 $ErrorActionPreference = "Stop"
 
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v8.1.0 Installer" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v8.2.0 Installer" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -169,10 +169,10 @@ if (Test-Path $SourceConfig) {
 # Create batch launcher (auto-installs deps if missing)
 $LauncherContent = @"
 @echo off
-title HeavyDrops Transcoder v8.1.0
+title HeavyDrops Transcoder v8.2.0
 cd /d "%~dp0"
 echo ========================================
-echo   HeavyDrops Transcoder v8.1.0
+echo   HeavyDrops Transcoder v8.2.0
 echo ========================================
 echo.
 REM Auto-install dependencies if missing
@@ -199,10 +199,10 @@ Set-Content -Path "$InstallDir\HeavyDrops Transcoder.bat" -Value $LauncherConten
 
 # PowerShell launcher (auto-installs deps if missing, keeps window open)
 $PSLauncherContent = @"
-`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v8.1.0"
+`$Host.UI.RawUI.WindowTitle = "HeavyDrops Transcoder v8.2.0"
 Set-Location "`$PSScriptRoot"
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  HeavyDrops Transcoder v8.1.0" -ForegroundColor Cyan
+Write-Host "  HeavyDrops Transcoder v8.2.0" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
@@ -236,7 +236,7 @@ $Shortcut = $WshShell.CreateShortcut("$env:PUBLIC\Desktop\HeavyDrops Transcoder.
 $Shortcut.TargetPath = "powershell.exe"
 $Shortcut.Arguments = "-ExecutionPolicy Bypass -NoExit -File `"$InstallDir\Launch.ps1`""
 $Shortcut.WorkingDirectory = $InstallDir
-$Shortcut.Description = "HeavyDrops Transcoder v8.1.0"
+$Shortcut.Description = "HeavyDrops Transcoder v8.2.0"
 $Shortcut.Save()
 Write-Host "   Desktop shortcut created" -ForegroundColor Gray
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "heavydrops-transcoder"
-version = "8.1.0"
+version = "8.2.0"
 description = "Minimal Dropbox H.264→H.265 transcoder. Daemon + dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/transcoder/config.py
+++ b/src/transcoder/config.py
@@ -229,10 +229,10 @@ class ApiSettings(BaseModel):
 
 
 class UpdaterSettings(BaseModel):
-    """Notify-only update check against GitHub Releases."""
+    """Update check against GitHub Releases, with optional self-update."""
     enabled: bool = Field(
         default=True,
-        description="When true, the daemon checks GitHub Releases on startup"
+        description="When true, the daemon checks GitHub Releases periodically"
     )
     github_repo: str = Field(
         default="luisimperator/rep01",
@@ -243,6 +243,27 @@ class UpdaterSettings(BaseModel):
         ge=1.0,
         le=60.0,
         description="Network timeout for the release check; failure is non-fatal"
+    )
+    check_interval_sec: float = Field(
+        default=1800.0,
+        ge=300.0,
+        le=86400.0,
+        description="Seconds between release checks (first check at startup)"
+    )
+    auto_apply: bool = Field(
+        default=True,
+        description=(
+            "When a newer release is published, pull it (git + pip) and "
+            "restart the daemon automatically; false = notify-only (dashboard "
+            "badge + manual `hd update`)"
+        )
+    )
+    windows_task_name: str = Field(
+        default="HeavyDropsDaemon",
+        description=(
+            "Scheduled-task name used to relaunch the daemon after a "
+            "self-update restart on Windows"
+        )
     )
 
 
@@ -1123,6 +1144,9 @@ def save_example_config(path: Path) -> None:
             'enabled': True,
             'github_repo': 'luisimperator/rep01',
             'check_timeout_sec': 5.0,
+            'check_interval_sec': 1800,
+            'auto_apply': True,
+            'windows_task_name': 'HeavyDropsDaemon',
         },
         'dropbox_api': {
             'rate_per_min': 600,

--- a/src/transcoder/main.py
+++ b/src/transcoder/main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import os
 import signal
+import subprocess
 import sys
 import threading
 import time
@@ -46,7 +47,7 @@ from .encoder_detect import (
 )
 from .rate_limit import TokenBucket
 from .scanner import Scanner
-from .updater import apply_update, check_for_update_async, installed_version
+from .updater import AutoUpdater, apply_update, detect_install_dir, installed_version
 from .watchdog import HealthChecker, Watchdog
 from .workers import AudioTranscoder, DownloadWorker, TranscodeWorker, UploadWorker
 from .inventory import (
@@ -59,6 +60,12 @@ from .inventory import (
 
 console = Console()
 logger = logging.getLogger(__name__)
+
+# Exit code used when the daemon shuts down ON PURPOSE to be relaunched by
+# its supervisor (auto-update restart). Nonzero so Task Scheduler's
+# RestartOnFailure / systemd's Restart=on-failure treat the run as one to
+# restart, not a clean stop.
+RESTART_EXIT_CODE = 42
 
 
 def setup_logging(verbose: bool = False, log_file: Path | None = None) -> None:
@@ -171,6 +178,8 @@ class Daemon:
         self.census_worker: CensusWorker | None = None
         self.deep_scan: DeepScanWorker | None = None
         self.incident_reporter = None  # IncidentReporter | None, set in setup()
+        self.auto_updater = None  # AutoUpdater | None, set in setup()
+        self.restart_requested = False
         self.stop_event = threading.Event()
         self.scan_trigger = threading.Event()
         self.started_at = time.time()
@@ -336,13 +345,29 @@ class Daemon:
         except Exception as e:
             logger.warning(f"could not run ffmpeg sanity transcode: {e}")
 
-        # Fire-and-forget GitHub release check; the HTTP API surfaces the result
-        # once it lands in the settings table.
+        # Periodic GitHub release check; the HTTP API surfaces the result once
+        # it lands in the settings table. With auto_apply on it also pulls a
+        # newer release in place and restarts the daemon to load it.
         if self.config.updater.enabled:
-            check_for_update_async(
+            upd = self.config.updater
+            install_dir = detect_install_dir()
+            self.auto_updater = AutoUpdater(
                 self.db,
-                self.config.updater.github_repo,
-                timeout_sec=self.config.updater.check_timeout_sec,
+                upd.github_repo,
+                self.stop_event,
+                timeout_sec=upd.check_timeout_sec,
+                interval_sec=upd.check_interval_sec,
+                auto_apply=upd.auto_apply,
+                install_dir=install_dir,
+                request_restart=self.request_restart,
+            )
+            self.auto_updater.start()
+            self.workers.append(self.auto_updater)
+            logger.info(
+                "updater: check every %ds, auto_apply=%s (install dir: %s)",
+                int(upd.check_interval_sec),
+                "ON" if upd.auto_apply else "off",
+                install_dir or "not a git checkout — apply disabled",
             )
 
         # Auto-incident reporter: opens GitHub Issues on transcode/scan
@@ -677,6 +702,18 @@ class Daemon:
                     logger.info("scan-now triggered via API")
                     break
 
+    def request_restart(self, reason: str) -> None:
+        """Shut down gracefully and get relaunched by the service supervisor.
+
+        Used by the auto-updater after pulling a new release: the running
+        process keeps the old code in memory, so a restart is the only way to
+        load it. In-flight jobs are safe — startup recovery requeues them and
+        reuses already-downloaded staging files.
+        """
+        logger.info(f"daemon restart requested: {reason}")
+        self.restart_requested = True
+        self.stop_event.set()
+
     def stop(self) -> None:
         """Signal all workers to stop."""
         logger.info("Stopping daemon...")
@@ -708,6 +745,65 @@ class Daemon:
             self.run_scan_loop()
         finally:
             self.stop()
+
+        if self.restart_requested:
+            self._exit_for_restart()
+
+    def _exit_for_restart(self) -> None:
+        """Exit so the service supervisor relaunches us with the new code.
+
+        On Windows a detached helper waits for this pid to die and then runs
+        ``schtasks /Run`` on the daemon's scheduled task for an immediate
+        relaunch; the nonzero exit code is the belt-and-braces fallback — the
+        task's RestartOnFailure (and systemd's Restart=on-failure on Linux)
+        relaunches a failed run on its own. Double starts are harmless: the
+        task ignores new instances while running and the daemon holds a
+        lockfile.
+        """
+        # Don't leave in-flight ffmpeg grinding as orphans across the restart
+        # gap; startup recovery requeues their jobs anyway.
+        try:
+            from .api import _kill_all_ffmpeg
+            _kill_all_ffmpeg()
+        except Exception:
+            logger.warning("could not kill in-flight ffmpeg before restart",
+                           exc_info=True)
+
+        if sys.platform == "win32":
+            task = self.config.updater.windows_task_name
+            script = (
+                f"$p = Get-Process -Id {os.getpid()} -ErrorAction SilentlyContinue; "
+                "if ($p) { $p.WaitForExit() }; "
+                "Start-Sleep -Seconds 3; "
+                f"schtasks /Run /TN \"{task}\""
+            )
+            flags = (
+                getattr(subprocess, "DETACHED_PROCESS", 0)
+                | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            )
+            try:
+                subprocess.Popen(
+                    ["powershell", "-NoProfile", "-WindowStyle", "Hidden",
+                     "-Command", script],
+                    creationflags=flags,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    close_fds=True,
+                )
+                logger.info(
+                    "restart helper armed: schtasks /Run /TN %s after exit", task
+                )
+            except Exception:
+                logger.warning(
+                    "could not arm the restart helper; relying on the task's "
+                    "RestartOnFailure (~5 min)", exc_info=True,
+                )
+
+        logger.info("exiting with code %d for supervisor restart",
+                    RESTART_EXIT_CODE)
+        sys.exit(RESTART_EXIT_CODE)
 
 
 # Click CLI

--- a/src/transcoder/updater.py
+++ b/src/transcoder/updater.py
@@ -1,12 +1,14 @@
 """
-Notify-only update checker backed by GitHub Releases.
+Update checker (and optional self-updater) backed by GitHub Releases.
 
-On daemon startup a background thread queries the configured repo's
-``/releases/latest`` endpoint, compares the published tag to the installed
-package version, and persists the result to the ``settings`` table. The HTTP
-API surfaces the flag so the GUI (or a curl check) can tell the user a new
-release is available. The daemon never self-updates — running ``hd update``
-applies it (``git pull`` + ``pip install -e .`` + daemon restart).
+The daemon runs an :class:`AutoUpdater` thread that periodically queries the
+configured repo's ``/releases/latest`` endpoint, compares the published tag
+to the installed package version, and persists the result to the ``settings``
+table (the HTTP API surfaces it to the dashboard). With ``updater.auto_apply``
+enabled, a newer release is also APPLIED in place — ``git pull --ff-only``
+plus ``pip install -e .`` when the manifest changed — and the daemon is asked
+to restart itself so the new code actually loads. With ``auto_apply`` off it
+degrades to the old notify-only behavior (``hd update`` applies manually).
 """
 
 from __future__ import annotations
@@ -146,21 +148,6 @@ def check_for_update(
         )
 
 
-def check_for_update_async(
-    db: Database,
-    github_repo: str,
-    timeout_sec: float = 5.0,
-) -> threading.Thread:
-    """Fire-and-forget the update check so daemon startup doesn't block on network."""
-    t = threading.Thread(
-        target=lambda: check_for_update(db, github_repo, timeout_sec),
-        name="updater",
-        daemon=True,
-    )
-    t.start()
-    return t
-
-
 def read_status(db: Database) -> UpdateStatus:
     """Load the last persisted update status (for the HTTP API)."""
     latest = db.get_setting(_SETTING_LATEST)
@@ -218,6 +205,135 @@ def apply_update(
 
     log_fn("update applied. Restart the daemon to pick up the new version.")
     return 0
+
+
+# ------------------------------------------------------------------ auto-update
+
+def detect_install_dir() -> Path | None:
+    """Locate the git checkout this package runs from, or None.
+
+    Editable installs (the bootstrap's ``pip install -e .``) import straight
+    from the checkout, so walking up from this file finds ``.git`` +
+    ``pyproject.toml``. A site-packages install finds neither — auto-apply
+    then stays off (there is no checkout to ``git pull``).
+    """
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() and (parent / "pyproject.toml").exists():
+            return parent
+    return None
+
+
+def _checkout_version(install_dir: Path) -> str:
+    """Read the version currently on disk in the checkout's pyproject.toml."""
+    try:
+        text = (Path(install_dir) / "pyproject.toml").read_text(encoding="utf-8")
+        m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        if m:
+            return m.group(1)
+    except OSError:
+        pass
+    return "0.0.0"
+
+
+class AutoUpdater(threading.Thread):
+    """Periodic release check that can apply updates and restart the daemon.
+
+    Every ``interval_sec`` (first check right at startup) the thread refreshes
+    the persisted update status. When ``auto_apply`` is on and a newer release
+    exists, it applies the update in place and calls ``request_restart`` — the
+    running process keeps executing the OLD code (Python has it in memory), so
+    only a restart loads the new version.
+
+    A tag whose apply fails (or that doesn't actually move the checkout's
+    version past the running one) is remembered and not retried, so a broken
+    checkout can't put the daemon in a pull/restart loop; publishing a newer
+    release resets the latch.
+    """
+
+    def __init__(
+        self,
+        db: Database,
+        github_repo: str,
+        stop_event: threading.Event,
+        *,
+        timeout_sec: float = 5.0,
+        interval_sec: float = 1800.0,
+        auto_apply: bool = False,
+        install_dir: Path | None = None,
+        request_restart: Callable[[str], None] | None = None,
+        check_fn: Callable[..., UpdateStatus] | None = None,
+        apply_fn: Callable[..., int] | None = None,
+    ) -> None:
+        super().__init__(name="updater", daemon=True)
+        self.db = db
+        self.github_repo = github_repo
+        self.stop_event = stop_event
+        self.timeout_sec = timeout_sec
+        self.interval_sec = interval_sec
+        self.auto_apply = auto_apply
+        self.install_dir = Path(install_dir) if install_dir else None
+        self.request_restart = request_restart
+        self._check_fn = check_fn or check_for_update
+        self._apply_fn = apply_fn or apply_update
+        # Version this process is actually RUNNING. installed_version() reads
+        # dist-info, which pip rewrites during apply — capture it now so the
+        # newer-than comparison stays anchored to the code in memory.
+        self._running_version = installed_version()
+        self._skip_tag: str | None = None
+
+    def run(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                self._tick()
+            except Exception:
+                logger.warning("update check crashed", exc_info=True)
+            self.stop_event.wait(self.interval_sec)
+
+    def _tick(self) -> None:
+        status = self._check_fn(self.db, self.github_repo, self.timeout_sec)
+        if not (status.update_available and status.latest_tag):
+            return
+        tag = status.latest_tag
+        if not self.auto_apply or self.request_restart is None:
+            return
+        if tag == self._skip_tag:
+            return
+        if self.install_dir is None:
+            logger.warning(
+                "auto-update: %s available but this install is not a git "
+                "checkout; apply it manually with `hd update`", tag,
+            )
+            self._skip_tag = tag
+            return
+
+        logger.info(
+            "auto-update: applying %s (running %s)", tag, self._running_version
+        )
+        rc = self._apply_fn(self.install_dir, log_fn=logger.info)
+        if rc != 0:
+            self._skip_tag = tag
+            logger.error(
+                "auto-update: apply of %s failed (rc=%d); leaving the daemon "
+                "as-is. Will only retry when a newer release is published.",
+                tag, rc,
+            )
+            return
+
+        on_disk = _checkout_version(self.install_dir)
+        if _normalize_version(on_disk) <= _normalize_version(self._running_version):
+            self._skip_tag = tag
+            logger.warning(
+                "auto-update: pulled %s but the checkout still holds %s "
+                "(running %s); not restarting.", tag, on_disk,
+                self._running_version,
+            )
+            return
+
+        logger.info(
+            "auto-update: %s applied (checkout now %s); restarting daemon "
+            "to load it", tag, on_disk,
+        )
+        self.request_restart(f"auto-update to {tag}")
 
 
 # ---------------------------------------------------------------------- helpers

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -1,0 +1,122 @@
+"""Tests for the AutoUpdater self-update loop.
+
+Covers the decision logic of one updater tick: when an update gets applied,
+when the daemon restart is requested, and the latches that keep a broken
+release from putting the daemon in a pull/restart loop.
+"""
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from transcoder.updater import (  # noqa: E402
+    AutoUpdater,
+    UpdateStatus,
+    detect_install_dir,
+)
+
+
+def _status(available: bool, tag: str | None = "v9.9.9") -> UpdateStatus:
+    return UpdateStatus(
+        current_version="8.2.0",
+        latest_tag=tag,
+        update_available=available,
+        checked_at="2026-07-15T00:00:00+00:00",
+        error=None,
+    )
+
+
+def _checkout(tmp_path: Path, version: str) -> Path:
+    """Fake git checkout with a pyproject.toml at the given version."""
+    (tmp_path / ".git").mkdir(exist_ok=True)
+    (tmp_path / "pyproject.toml").write_text(
+        f'[project]\nname = "x"\nversion = "{version}"\n', encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _make(tmp_path, *, available=True, apply_rc=0, auto_apply=True,
+          install_dir="auto", pulled_version="9.9.9"):
+    """AutoUpdater wired with stubs; returns (updater, apply_fn, restart)."""
+    checkout = _checkout(tmp_path, pulled_version)
+    apply_fn = MagicMock(return_value=apply_rc)
+    restart = MagicMock()
+    upd = AutoUpdater(
+        MagicMock(),  # db — only the injected check_fn touches it
+        "luisimperator/rep01",
+        threading.Event(),
+        auto_apply=auto_apply,
+        install_dir=checkout if install_dir == "auto" else install_dir,
+        request_restart=restart,
+        check_fn=lambda *a, **k: _status(available),
+        apply_fn=apply_fn,
+    )
+    upd._running_version = "8.2.0"
+    return upd, apply_fn, restart
+
+
+class TestAutoApply:
+    def test_newer_release_is_applied_and_daemon_restarts(self, tmp_path):
+        upd, apply_fn, restart = _make(tmp_path)
+        upd._tick()
+        apply_fn.assert_called_once()
+        restart.assert_called_once_with("auto-update to v9.9.9")
+
+    def test_no_update_available_does_nothing(self, tmp_path):
+        upd, apply_fn, restart = _make(tmp_path, available=False)
+        upd._tick()
+        apply_fn.assert_not_called()
+        restart.assert_not_called()
+
+    def test_auto_apply_off_is_notify_only(self, tmp_path):
+        upd, apply_fn, restart = _make(tmp_path, auto_apply=False)
+        upd._tick()
+        apply_fn.assert_not_called()
+        restart.assert_not_called()
+
+    def test_non_git_install_never_applies(self, tmp_path):
+        upd, apply_fn, restart = _make(tmp_path, install_dir=None)
+        upd._tick()
+        apply_fn.assert_not_called()
+        restart.assert_not_called()
+
+
+class TestNoRestartLoops:
+    def test_failed_apply_is_not_retried_for_same_tag(self, tmp_path):
+        upd, apply_fn, restart = _make(tmp_path, apply_rc=1)
+        upd._tick()
+        upd._tick()
+        apply_fn.assert_called_once()  # second tick skips the latched tag
+        restart.assert_not_called()
+
+    def test_newer_tag_resets_the_failure_latch(self, tmp_path):
+        upd, apply_fn, restart = _make(tmp_path, apply_rc=1)
+        upd._tick()
+        apply_fn.assert_called_once()
+
+        # A NEW release supersedes the broken one — try again.
+        upd._check_fn = lambda *a, **k: _status(True, tag="v10.0.0")
+        upd._apply_fn = MagicMock(return_value=0)
+        upd._tick()
+        upd._apply_fn.assert_called_once()
+        restart.assert_called_once_with("auto-update to v10.0.0")
+
+    def test_pull_that_does_not_advance_version_does_not_restart(self, tmp_path):
+        """Tag published but the checkout still holds the running version
+        (e.g. pull landed on an unexpected branch) — restarting would loop."""
+        upd, apply_fn, restart = _make(tmp_path, pulled_version="8.2.0")
+        upd._tick()
+        upd._tick()
+        apply_fn.assert_called_once()
+        restart.assert_not_called()
+
+
+def test_detect_install_dir_finds_this_checkout():
+    found = detect_install_dir()
+    assert found is not None
+    assert (found / "pyproject.toml").exists()
+    assert (found / ".git").exists()

--- a/transcoder_gui.py
+++ b/transcoder_gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-HeavyDrops Transcoder v8.1.0
+HeavyDrops Transcoder v8.2.0
 
 Dropbox Video Transcoder - GUI Version
 Simple graphical interface for local folder transcoding.
@@ -16,7 +16,7 @@ Features:
 - Beep notification when queue finishes
 """
 
-VERSION = "8.1.0"
+VERSION = "8.2.0"
 
 import socket
 import subprocess


### PR DESCRIPTION
Recriação do #213 (fechado só por causa de um rate limit do GraphQL que impedia tirá-lo de draft).

## O que muda

O updater deixa de ser só aviso e passa a **se atualizar sozinho**:

- **`AutoUpdater` thread** (`updater.py`): checa as releases do GitHub a cada 30 min (`updater.check_interval_sec`, primeira checagem no boot). Saiu release nova → `git pull --ff-only` + `pip install -e .` (só quando o `pyproject.toml` mudou) → pede restart do daemon pra carregar o código novo.
- **Restart automático** (`main.py`): shutdown limpo, mata os ffmpeg em voo (sem órfãos), arma um helper PowerShell destacado que espera o pid antigo morrer e roda `schtasks /Run /TN HeavyDropsDaemon`; sai com exit code dedicado 42 pra o `RestartOnFailure` da task servir de plano B (~5 min) se o helper falhar. Dupla partida é inofensiva: `IgnoreNew` na task + lockfile do daemon. O boot recupera os jobs em voo e reaproveita os downloads já feitos (comprovado na subida da 8.1.0: "Recovered 631 interrupted jobs").
- **Guardas contra loop**: tag cujo apply falhou — ou que não avançou a versão do checkout além da que está rodando — fica marcada e só é tentada de novo quando sair release MAIS nova; instalação que não é checkout git nunca tenta aplicar.
- **Config**: `updater.auto_apply` (padrão `true`; `false` = volta ao aviso no dashboard + `hd update` manual), `updater.check_interval_sec`, `updater.windows_task_name`.
- Versão 8.2.0 em todos os arquivos (sync_version) + seção nova no `NOTAS_DA_VERSAO.txt`.

## Pipeline completo

Com o workflow de release (#211/#212), **mergear um bump de versão no main é o deploy inteiro**: a release publica sozinha no merge, e cada máquina se atualiza e reinicia sozinha em até ~30 min.

## Testes

- `tests/test_auto_update.py` novo: 8 testes (aplica + reinicia; nada quando não há update / auto_apply off / instalação sem git; latch de apply falhado; release mais nova reseta o latch; pull que não avança versão não reinicia; `detect_install_dir`).
- Suíte completa: **154 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bbMXYJJjbgyBkgA8dJJ8a

---
_Generated by [Claude Code](https://claude.ai/code/session_011bbMXYJJjbgyBkgA8dJJ8a)_